### PR TITLE
Advance the port all the way to the end of 2022.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.0.7+llvm-f45d5e71d3e1"
+version = "0.0.8+llvm-462a31f5a5ab"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.0.0"
+version = "0.0.0+llvm-f3598e8fca83"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.0.3+llvm-2b6b8cb10c87"
+version = "0.0.4+llvm-b198f1f86ce0"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.0.5+llvm-a2588948febc"
+version = "0.0.6+llvm-6dabc38cce73"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.0.0+llvm-f3598e8fca83"
+version = "0.0.1+llvm-768d6dd08783"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.0.6+llvm-6dabc38cce73"
+version = "0.0.7+llvm-f45d5e71d3e1"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.0.8+llvm-462a31f5a5ab"
+version = "0.1.0+llvm-462a31f5a5ab"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.0.2+llvm-69f6098e8931"
+version = "0.0.3+llvm-2b6b8cb10c87"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.0.1+llvm-768d6dd08783"
+version = "0.0.2+llvm-69f6098e8931"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.0.4+llvm-b198f1f86ce0"
+version = "0.0.5+llvm-a2588948febc"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,68 @@
-# `rustc_apfloat` (Rust port of C++ `llvm::APFloat` library)
+# `rustc_apfloat`<br><sub>(Rust port of the C++ `llvm::APFloat` "softfloat" library)</sub>
 
-## 🚧 Work In Progress 🚧
+## History
 
-**NOTE**: the repo (and [`rustc_apfloat-git-history-extraction`](https://github.com/LykenSol/rustc_apfloat-git-history-extraction)) might be public already, but only for convenience of discussion, see [relevant Zulip topic](https://rust-lang.zulipchat.com/#narrow/stream/231349-t-core.2Flicensing/topic/apfloat) for more details.
+LLVM's `APFloat` (aka `llvm::APFloat`) software floating-point (or "softfloat")
+library was first ported to Rust (and named `rustc_apfloat`) back in 2017,
+in the Rust pull request [`rust-lang/rust#43554`](https://github.com/rust-lang/rust/pull/43554),
+as part of an effort to expand Rust compile-time capabilities without sacrificing
+determinism (and therefore soundness, if the type-system was involved).
+
+<sub>Note: while using the original C++ `llvm::APFloat` directly would've been an option,
+certain high-level API design differences made in the Rust port, without behavioral impact
+(C++ raw pointers and dynamic allocations vs Rust generics, traits and `#![no_std]`),
+made the Rust port more appealing from a determinism standpoint (mostly thanks to
+lacking all 3 of: `unsafe` code, host floating-point use, `std` access - and only
+allocating to handle the arbitrary precision needed for conversions to/from decimal),
+*even though there was a chance it had correctness issues unique to it*.</sub>
+
+However, that port had a fatal flaw: it was added to the `rust-lang/rust` repository
+without its unique licensing status (as a port of a C++ library with its own license)
+being properly tracked, communicated, taken into account, etc.  
+The end result was years of limbo, mostly chronicled in the Rust issue
+[`rust-lang/rust#55993`](https://github.com/rust-lang/rust/issues/55993), in which
+the in-tree port couldn't really receive proper updated or even maintenance, due
+due to its unclear status.
+
+### Revival (as `rust-lang/rustc_apfloat`)
+
+This repository (`rust-lang/rustc_apfloat`) is the result of a 2022 plan on
+[the relevant Zulip topic](https://rust-lang.zulipchat.com/#narrow/stream/231349-t-core.2Flicensing/topic/apfloat), fully put into motion during 2023:
+* the `git` history of the in-tree `compiler/rustc_apfloat` library was extracted  
+  (see the separate [`rustc_apfloat-git-history-extraction`](https://github.com/LykenSol/rustc_apfloat-git-history-extraction) repository for more details)
+* only commits that were *both* necessary *and* had clear copyright status, were kept
+* any missing functionality or bug fixes, would have to be either be re-contributed,  
+  or rebuilt from the ground up (mostly the latter ended up being done, see below)
+
+Most changes since the original port had been aesthetic (e.g. spell-checking, `rustfmt`),
+so little was lost in the process.
+
+Starting from that much smaller "trusted" base:
+* everything could use LLVM's new (since 2019) license, "`Apache-2.0 WITH LLVM-exception`"  
+  (see the ["Licensing"](#licensing) section below and/or [LICENSE-DETAILS.md](./LICENSE-DETAILS.md) for more details)
+* new facilities were built (benchmarks, and [a fuzzer comparing Rust/C++/hardware](#fuzzing))
+* excessive testing was performed (via a combination of fuzzing and bruteforce search)
+* latent bugs were discovered (e.g. LLVM issues
+[#63895](https://github.com/llvm/llvm-project/issues/63895) and
+[#63938](https://github.com/llvm/llvm-project/issues/63938))
+* the port has been forwarded in time, to include upstream (`llvm/llvm-project`) changes   
+  to `llvm::APFloat` over the years (since 2017), removing the need for selective backports
+
+## Versioning
+
+As this is, for the time being, a "living port", tracking upstream (`llvm/llvm-project`)  
+`llvm::APFloat` changes, the `rustc_apfloat` crate will have versions of the form:
+
+```
+0.X.Y+llvm-ZZZZZZZZZZZZ
+```
+* `X` is always bumped after semver-incompatible API changes,  
+  or when updating the upstream (`llvm/llvm-project`) commit the port is based on
+* `Y` is only bumped when other parts of the version don't need to be (e.g. for bug fixes)
+* `+llvm-ZZZZZZZZZZZZ` is ["version metadata"](https://doc.rust-lang.org/cargo/reference/resolver.html#version-metadata) (which Cargo itself ignores),  
+  and `ZZZZZZZZZZZZ` always holds the first 12 hexadecimal digits of  
+  the upstream (`llvm/llvm-project`) `git` commit hash the port is based on
+
 
 ## Testing
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,41 @@
+// HACK(eddyb) easier dep-tracking if we let `rustc` do it.
+const SRC_LIB_RS_CONTENTS: &str = include_str!("src/lib.rs");
+
+const EXPECTED_SRC_LIB_RS_PREFIX: &str = "\
+//! Port of LLVM's APFloat software floating-point implementation from the
+//! following C++ sources (please update commit hash when backporting):
+//! https://github.com/llvm/llvm-project/commit/";
+
+fn main() {
+    // HACK(eddyb) disable the default of re-running the build script on *any*
+    // change to *the entire source tree* (i.e. the default is roughly `./`).
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let llvm_commit_hash = SRC_LIB_RS_CONTENTS
+        .strip_prefix(EXPECTED_SRC_LIB_RS_PREFIX)
+        .ok_or(())
+        .map_err(|_| format!("expected `src/lib.rs` to start with:\n\n{EXPECTED_SRC_LIB_RS_PREFIX}"))
+        .and_then(|commit_hash_plus_rest_of_file| {
+            Ok(commit_hash_plus_rest_of_file
+                .split_once('\n')
+                .ok_or("expected `src/lib.rs` to have more than 3 lines")?)
+        })
+        .and_then(|(commit_hash, _)| {
+            if commit_hash.len() != 40 || !commit_hash.chars().all(|c| matches!(c, '0'..='9'|'a'..='f')) {
+                Err(format!("expected `src/lib.rs` to have a valid commit hash, found {commit_hash:?}"))
+            } else {
+                Ok(commit_hash)
+            }
+        })
+        .unwrap_or_else(|e| {
+            eprintln!("\n{e}\n");
+            panic!("failed to validate `src/lib.rs`'s commit hash (see above)")
+        });
+
+    let expected_version_metadata = format!("+llvm-{}", &llvm_commit_hash[..12]);
+    let actual_version = env!("CARGO_PKG_VERSION");
+    if !actual_version.ends_with(&expected_version_metadata) {
+        eprintln!("\nexpected version ending in `{expected_version_metadata}`, found `{actual_version}`\n");
+        panic!("failed to validate Cargo package version (see above)");
+    }
+}

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -68,7 +68,7 @@ curl -sS "$llvm_project_tgz_url" | tar -C "$OUT_DIR" -xz
 llvm="$OUT_DIR"/llvm-project-"$llvm_project_git_hash"/llvm
 
 mkdir -p "$OUT_DIR"/fake-config/llvm/Config
-touch "$OUT_DIR"/fake-config/llvm/Config/{abi-breaking,llvm-config}.h
+touch "$OUT_DIR"/fake-config/llvm/Config/{abi-breaking,config,llvm-config}.h
 
 # HACK(eddyb) we want standard `assert`s to work, but `NDEBUG` also controls
 # unrelated LLVM facilities that are spread all over the place and it's harder
@@ -91,8 +91,8 @@ echo | clang++ -x c++ - -std=c++17 \
   $clang_codegen_flags \
   -I "$llvm"/include \
   -I "$OUT_DIR"/fake-config \
-  -DNDEBUG \
-  --include="$llvm"/lib/Support/{APInt,APFloat,SmallVector}.cpp \
+  -DNDEBUG -DHAVE_UNISTD_H \
+  --include="$llvm"/lib/Support/{APInt,APFloat,SmallVector,ErrorHandling}.cpp \
   --include="$OUT_DIR"/cxx_apf_fuzz.cpp \
   -c -emit-llvm -o "$OUT_DIR"/cxx_apf_fuzz.bc
 

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -91,7 +91,7 @@ echo | clang++ -x c++ - -std=c++17 \
   $clang_codegen_flags \
   -I "$llvm"/include \
   -I "$OUT_DIR"/fake-config \
-  -DNDEBUG -DHAVE_UNISTD_H \
+  -DNDEBUG -DHAVE_UNISTD_H -DLLVM_ON_UNIX \
   --include="$llvm"/lib/Support/{APInt,APFloat,SmallVector,ErrorHandling}.cpp \
   --include="$OUT_DIR"/cxx_apf_fuzz.cpp \
   -c -emit-llvm -o "$OUT_DIR"/cxx_apf_fuzz.bc

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -91,7 +91,7 @@ echo | clang++ -x c++ - -std=c++17 \
   $clang_codegen_flags \
   -I "$llvm"/include \
   -I "$OUT_DIR"/fake-config \
-  -DNDEBUG -DHAVE_UNISTD_H -DLLVM_ON_UNIX \
+  -DNDEBUG -DHAVE_UNISTD_H -DLLVM_ON_UNIX -DLLVM_ENABLE_THREADS=0 \
   --include="$llvm"/lib/Support/{APInt,APFloat,SmallVector,ErrorHandling}.cpp \
   --include="$OUT_DIR"/cxx_apf_fuzz.cpp \
   -c -emit-llvm -o "$OUT_DIR"/cxx_apf_fuzz.bc

--- a/fuzz/ops.rs
+++ b/fuzz/ops.rs
@@ -280,11 +280,13 @@ struct FuzzOp {
         (32, "APFloat::IEEEsingle()"),
         (64, "APFloat::IEEEdouble()"),
         (128, "APFloat::IEEEquad()"),
+        (16, "APFloat::BFloat()"),
         (80, "APFloat::x87DoubleExtended()"),
     ]
     .into_iter()
     .map(|(w, cxx_apf_semantics)| {
         let (name_prefix, uint_width) = match w {
+            16 if cxx_apf_semantics.contains("BFloat") => ("BrainF", 16),
             80 => ("X87_F", 128),
             _ => ("IEEE", w),
         };

--- a/fuzz/src/main.rs
+++ b/fuzz/src/main.rs
@@ -206,6 +206,16 @@ float_reprs! {
     }
 
     // Non-standard IEEE-like formats.
+    F8E5M2(u8) {
+        type RustcApFloat = rustc_apfloat::ieee::Float8E5M2;
+        const REPR_TAG = 8 + 0;
+        extern fn = cxx_apf_fuzz_eval_op_f8e5m2;
+    }
+    F8E4M3FN(u8) {
+        type RustcApFloat = rustc_apfloat::ieee::Float8E4M3FN;
+        const REPR_TAG = 8 + 1;
+        extern fn = cxx_apf_fuzz_eval_op_f8e4m3fn;
+    }
     BrainF16(u16) {
         type RustcApFloat = rustc_apfloat::ieee::BFloat;
         const REPR_TAG = 16 + 1;

--- a/fuzz/src/main.rs
+++ b/fuzz/src/main.rs
@@ -21,10 +21,6 @@ struct Args {
     #[arg(long)]
     strict_hard_nan_sign: bool,
 
-    /// Disable erasure of sNaN vs qNaN mismatches with hardware floating-point operations
-    #[arg(long)]
-    strict_hard_qnan_vs_snan: bool,
-
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -315,10 +311,7 @@ where
             // FIXME(eddyb) figure out how much we can really validate against hardware.
             let rs_apf_bits = out.rs_apf.to_bits_u128();
             if is_nan(out_hard_bits) && is_nan(rs_apf_bits) {
-                for (strict, bit_mask) in [
-                    (cli_args.strict_hard_nan_sign, sign_bit_mask),
-                    (cli_args.strict_hard_qnan_vs_snan, qnan_bit_mask),
-                ] {
+                for (strict, bit_mask) in [(cli_args.strict_hard_nan_sign, sign_bit_mask)] {
                     if !strict {
                         out_hard_bits &= !bit_mask;
                         out_hard_bits |= rs_apf_bits & bit_mask;

--- a/src/ieee.rs
+++ b/src/ieee.rs
@@ -165,7 +165,7 @@ impl<S> Clone for IeeeFloat<S> {
 }
 
 macro_rules! ieee_semantics {
-    ($($name:ident = $sem:ident($bits:tt : $exp_bits:tt)),*) => {
+    ($($name:ident = $sem:ident($bits:tt : $exp_bits:tt)),* $(,)?) => {
         $(pub struct $sem;)*
         $(pub type $name = IeeeFloat<$sem>;)*
         $(impl Semantics for $sem {
@@ -180,7 +180,10 @@ ieee_semantics! {
     Half = HalfS(16:5),
     Single = SingleS(32:8),
     Double = DoubleS(64:11),
-    Quad = QuadS(128:15)
+    Quad = QuadS(128:15),
+
+    // Non-standard IEEE-like semantics.
+    BFloat = BFloatS(16:8),
 }
 
 pub struct X87DoubleExtendedS;

--- a/src/ieee.rs
+++ b/src/ieee.rs
@@ -1003,6 +1003,8 @@ impl<S: Semantics> Float for IeeeFloat<S> {
             (Category::Infinity, _) | (_, Category::Zero) => Status::INVALID_OP.and(Self::NAN),
 
             (Category::Normal, Category::Normal) => {
+                let orig_sign = self.sign;
+
                 while self.is_finite_non_zero()
                     && rhs.is_finite_non_zero()
                     && self.cmp_abs_normal(rhs) != Ordering::Less
@@ -1016,6 +1018,9 @@ impl<S: Semantics> Float for IeeeFloat<S> {
                     let status;
                     self = unpack!(status=, self - v);
                     assert_eq!(status, Status::OK);
+                }
+                if self.is_zero() {
+                    self.sign = orig_sign;
                 }
                 Status::OK.and(self)
             }
@@ -1182,8 +1187,8 @@ impl<S: Semantics> Float for IeeeFloat<S> {
 
         // Handle special cases.
         match s {
-            "inf" | "INFINITY" => return Ok(Status::OK.and(Self::INFINITY)),
-            "-inf" | "-INFINITY" => return Ok(Status::OK.and(-Self::INFINITY)),
+            "inf" | "INFINITY" | "+Inf" => return Ok(Status::OK.and(Self::INFINITY)),
+            "-inf" | "-INFINITY" | "-Inf" => return Ok(Status::OK.and(-Self::INFINITY)),
             "nan" | "NaN" => return Ok(Status::OK.and(Self::NAN)),
             "-nan" | "-NaN" => return Ok(Status::OK.and(-Self::NAN)),
             _ => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Port of LLVM's APFloat software floating-point implementation from the
 //! following C++ sources (please update commit hash when backporting):
-//! https://github.com/llvm/llvm-project/commit/69f6098e89312b934ed87e4cd3603401a9b436b4
+//! https://github.com/llvm/llvm-project/commit/2b6b8cb10c870d64f7cc29d21fc27cef3c7e0056
 //! * `llvm/include/llvm/ADT/APFloat.h` -> `Float` and `FloatConvert` traits
 //! * `llvm/lib/Support/APFloat.cpp` -> `ieee` and `ppc` modules
 //! * `llvm/unittests/ADT/APFloatTest.cpp` -> `tests` directory
@@ -48,6 +48,11 @@ bitflags! {
     /// IEEE-754R 7: Default exception handling.
     ///
     /// UNDERFLOW or OVERFLOW are always returned or-ed with INEXACT.
+    ///
+    /// APFloat models this behavior specified by IEEE-754:
+    ///   "For operations producing results in floating-point format, the default
+    ///    result of an operation that signals the invalid operation exception
+    ///    shall be a quiet NaN."
     #[must_use]
     pub struct Status: u8 {
         const OK = 0x00;
@@ -132,7 +137,7 @@ impl Neg for Round {
 }
 
 /// A signed type to represent a floating point number's unbiased exponent.
-pub type ExpInt = i16;
+pub type ExpInt = i32;
 
 // \c ilogb error results.
 pub const IEK_INF: ExpInt = ExpInt::max_value();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Port of LLVM's APFloat software floating-point implementation from the
 //! following C++ sources (please update commit hash when backporting):
-//! https://github.com/llvm/llvm-project/commit/a2588948febccfed5ba074fc32dcb093484fa5c8
+//! https://github.com/llvm/llvm-project/commit/6dabc38cce73549ed747c537f81f6f4dd79eba39
 //! * `llvm/include/llvm/ADT/APFloat.h` -> `Float` and `FloatConvert` traits
 //! * `llvm/lib/Support/APFloat.cpp` -> `ieee` and `ppc` modules
 //! * `llvm/unittests/ADT/APFloatTest.cpp` -> `tests` directory

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Port of LLVM's APFloat software floating-point implementation from the
 //! following C++ sources (please update commit hash when backporting):
-//! https://github.com/llvm/llvm-project/commit/6dabc38cce73549ed747c537f81f6f4dd79eba39
+//! https://github.com/llvm/llvm-project/commit/f45d5e71d3e1ef9d565815850681719418a99d19
 //! * `llvm/include/llvm/ADT/APFloat.h` -> `Float` and `FloatConvert` traits
 //! * `llvm/lib/Support/APFloat.cpp` -> `ieee` and `ppc` modules
 //! * `llvm/unittests/ADT/APFloatTest.cpp` -> `tests` directory

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Port of LLVM's APFloat software floating-point implementation from the
 //! following C++ sources (please update commit hash when backporting):
-//! https://github.com/llvm/llvm-project/commit/f3598e8fca83ccfb11f58ec7957c229e349765e3
+//! https://github.com/llvm/llvm-project/commit/768d6dd08783440606da83dac490889329619898
 //! * `llvm/include/llvm/ADT/APFloat.h` -> `Float` and `FloatConvert` traits
 //! * `llvm/lib/Support/APFloat.cpp` -> `ieee` and `ppc` modules
 //! * `llvm/unittests/ADT/APFloatTest.cpp` -> `tests` directory

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Port of LLVM's APFloat software floating-point implementation from the
 //! following C++ sources (please update commit hash when backporting):
-//! https://github.com/llvm/llvm-project/commit/f45d5e71d3e1ef9d565815850681719418a99d19
+//! https://github.com/llvm/llvm-project/commit/462a31f5a5abb905869ea93cc49b096079b11aa4
 //! * `llvm/include/llvm/ADT/APFloat.h` -> `Float` and `FloatConvert` traits
 //! * `llvm/lib/Support/APFloat.cpp` -> `ieee` and `ppc` modules
 //! * `llvm/unittests/ADT/APFloatTest.cpp` -> `tests` directory
@@ -525,11 +525,23 @@ pub trait Float:
     fn is_neg_zero(self) -> bool {
         self.is_zero() && self.is_negative()
     }
+    fn is_pos_infinity(self) -> bool {
+        self.is_infinite() && !self.is_negative()
+    }
+    fn is_neg_infinity(self) -> bool {
+        self.is_infinite() && self.is_negative()
+    }
 
     /// Returns true if and only if the number has the smallest possible non-zero
     /// magnitude in the current semantics.
     fn is_smallest(self) -> bool {
         Self::SMALLEST.copy_sign(self).bitwise_eq(self)
+    }
+
+    /// Returns true if this is the smallest (by magnitude) normalized finite
+    /// number in the given semantics.
+    fn is_smallest_normalized(self) -> bool {
+        Self::smallest_normalized().copy_sign(self).bitwise_eq(self)
     }
 
     /// Returns true if and only if the number has the largest possible finite

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Port of LLVM's APFloat software floating-point implementation from the
 //! following C++ sources (please update commit hash when backporting):
-//! https://github.com/llvm/llvm-project/commit/b198f1f86ce09b86825dd6d80de2c72a617e27f7
+//! https://github.com/llvm/llvm-project/commit/a2588948febccfed5ba074fc32dcb093484fa5c8
 //! * `llvm/include/llvm/ADT/APFloat.h` -> `Float` and `FloatConvert` traits
 //! * `llvm/lib/Support/APFloat.cpp` -> `ieee` and `ppc` modules
 //! * `llvm/unittests/ADT/APFloatTest.cpp` -> `tests` directory

--- a/src/ppc.rs
+++ b/src/ppc.rs
@@ -407,6 +407,10 @@ where
         self.0.category()
     }
 
+    fn is_integer(self) -> bool {
+        self.0.is_integer() && self.1.is_integer()
+    }
+
     fn get_exact_inverse(self) -> Option<Self> {
         Fallback::from(self).get_exact_inverse().map(Self::from)
     }
@@ -427,4 +431,14 @@ where
         }
         DoubleFloat(a, b)
     }
+}
+
+// HACK(eddyb) this is here instead of in `tests/ppc.rs` because `DoubleFloat`
+// has private fields, and it's not worth it to make them public just for testing.
+#[test]
+fn is_integer() {
+    let double_from_f64 = |f: f64| ieee::Double::from_bits(f.to_bits().into());
+    assert!(DoubleFloat(double_from_f64(-0.0), double_from_f64(-0.0)).is_integer());
+    assert!(!DoubleFloat(double_from_f64(3.14159), double_from_f64(-0.0)).is_integer());
+    assert!(!DoubleFloat(double_from_f64(-0.0), double_from_f64(3.14159)).is_integer());
 }

--- a/src/ppc.rs
+++ b/src/ppc.rs
@@ -336,6 +336,10 @@ where
         Fallback::from(self).div_r(Fallback::from(rhs), round).map(Self::from)
     }
 
+    fn ieee_rem(self, rhs: Self) -> StatusAnd<Self> {
+        Fallback::from(self).ieee_rem(Fallback::from(rhs)).map(Self::from)
+    }
+
     fn c_fmod(self, rhs: Self) -> StatusAnd<Self> {
         Fallback::from(self).c_fmod(Fallback::from(rhs)).map(Self::from)
     }
@@ -396,7 +400,7 @@ where
         self.category() == Category::Normal
             && (self.0.is_denormal() || self.0.is_denormal() ||
           // (double)(Hi + Lo) == Hi defines a normal number.
-          !(self.0 + self.1).value.bitwise_eq(self.0))
+          self.0 !=  (self.0 + self.1).value)
     }
 
     fn is_signaling(self) -> bool {

--- a/src/ppc.rs
+++ b/src/ppc.rs
@@ -35,6 +35,8 @@ type Fallback<F> = ieee::IeeeFloat<FallbackS<F>>;
 impl<F: Float> ieee::Semantics for FallbackS<F> {
     // Forbid any conversion to/from bits.
     const BITS: usize = 0;
+    const EXP_BITS: usize = 0;
+
     const PRECISION: usize = F::PRECISION * 2;
     const MAX_EXP: ExpInt = F::MAX_EXP as ExpInt;
     const MIN_EXP: ExpInt = F::MIN_EXP as ExpInt + F::PRECISION as ExpInt;
@@ -50,8 +52,11 @@ type FallbackExtended<F> = ieee::IeeeFloat<FallbackExtendedS<F>>;
 impl<F: Float> ieee::Semantics for FallbackExtendedS<F> {
     // Forbid any conversion to/from bits.
     const BITS: usize = 0;
+    const EXP_BITS: usize = 0;
+
     const PRECISION: usize = Fallback::<F>::PRECISION;
     const MAX_EXP: ExpInt = F::MAX_EXP as ExpInt;
+    const MIN_EXP: ExpInt = F::MIN_EXP as ExpInt;
 }
 
 impl<F: Float> From<Fallback<F>> for DoubleFloat<F>

--- a/tests/downstream.rs
+++ b/tests/downstream.rs
@@ -391,10 +391,7 @@ fn fuzz_fma_with_expected_outputs() {
 // found many examples in all ops, as the root issue was the handling of the
 // bit-level encoding itself, but negation was the easiest op to test here).
 pub const FUZZ_X87_F80_NEG_CASES_WITH_EXPECTED_OUTPUTS: &[(u128, u128)] = &[
-    (
-        0x01010101010100000000, /* 3.05337213397376214408E-4857 */
-        0x81010101010100000000, /* -3.05337213397376214408E-4857 */
-    ),
+    (0x01010101010100000000 /* NaN */, 0xffff0101010100000000 /* NaN */),
     (
         0x0000ff7f2300ff000000, /* 6.71098449692300485303E-4932 */
         0x8001ff7f2300ff000000, /* -6.71098449692300485303E-4932 */

--- a/tests/downstream.rs
+++ b/tests/downstream.rs
@@ -46,7 +46,7 @@ fn fuzz_roundtrip_through_i128() {
 // `f32` FMA bit-patterns which used to produce the wrong output (found by fuzzing).
 pub const FUZZ_IEEE32_FMA_CASES_WITH_EXPECTED_OUTPUTS: &[((u32, u32, u32), u32)] = &[
     ((0x00001000 /* 5.74e-42 */, 0x0000001a /* 3.6e-44 */, 0xffff1a00 /* NaN */), 0xffff1a00 /* NaN */),
-    ((0x000080aa /* 4.6156e-41 */, 0xaaff0000 /* -4.52971e-13 */, 0xff9e007f /* NaN */), 0xff9e007f /* NaN */),
+    ((0x000080aa /* 4.6156e-41 */, 0xaaff0000 /* -4.52971e-13 */, 0xff9e007f /* NaN */), 0xffde007f /* NaN */),
     ((0x0000843f /* 4.7441e-41 */, 0x0084ff80 /* 1.2213942e-38 */, 0xffff8000 /* NaN */), 0xffff8000 /* NaN */),
     ((0x00009eaa /* 5.6918e-41 */, 0x201d7f1e /* 1.3340477e-19 */, 0xffff0001 /* NaN */), 0xffff0001 /* NaN */),
     ((0x020400ff /* 9.698114e-38 */, 0x7f7f2200 /* 3.3912968e+38 */, 0xffffffff /* NaN */), 0xffffffff /* NaN */),
@@ -63,22 +63,22 @@ pub const FUZZ_IEEE32_FMA_CASES_WITH_EXPECTED_OUTPUTS: &[((u32, u32, u32), u32)]
     ((0x200004aa /* 1.0843565e-19 */, 0x00202020 /* 2.95026e-39 */, 0x7fff00ff /* NaN */), 0x7fff00ff /* NaN */),
     (
         (0x20005eaa /* 1.0873343e-19 */, 0x9e9e9e3a /* -1.6794342e-20 */, 0xff9e009e /* NaN */),
-        0xff9e009e, /* NaN */
+        0xffde009e, /* NaN */
     ),
-    ((0x20007faa /* 1.0884262e-19 */, 0x9e00611e /* -6.796347e-21 */, 0x7faa0600 /* NaN */), 0x7faa0600 /* NaN */),
+    ((0x20007faa /* 1.0884262e-19 */, 0x9e00611e /* -6.796347e-21 */, 0x7faa0600 /* NaN */), 0x7fea0600 /* NaN */),
     (
         (0x20007faa /* 1.0884262e-19 */, 0xaa069e1e /* -1.1956449e-13 */, 0xffffecff /* NaN */),
         0xffffecff, /* NaN */
     ),
-    ((0x20025eaa /* 1.104275e-19 */, 0x9e01033a /* -6.82987e-21 */, 0xff9e009e /* NaN */), 0xff9e009e /* NaN */),
+    ((0x20025eaa /* 1.104275e-19 */, 0x9e01033a /* -6.82987e-21 */, 0xff9e009e /* NaN */), 0xffde009e /* NaN */),
     ((0x3314f400 /* 3.4680852e-8 */, 0x00ff7903 /* 2.3461462e-38 */, 0xffffffdb /* NaN */), 0xffffffdb /* NaN */),
     ((0x3314f400 /* 3.4680852e-8 */, 0x00ff7903 /* 2.3461462e-38 */, 0xfffffff6 /* NaN */), 0xfffffff6 /* NaN */),
-    ((0x3a218275 /* 0.0006161102 */, 0x3a3a3a3a /* 0.00071040133 */, 0x7f8a063a /* NaN */), 0x7f8a063a /* NaN */),
+    ((0x3a218275 /* 0.0006161102 */, 0x3a3a3a3a /* 0.00071040133 */, 0x7f8a063a /* NaN */), 0x7fca063a /* NaN */),
     ((0x40000001 /* 2.0000002 */, 0xfefffffe /* -1.7014116e+38 */, 0xfffe40ff /* NaN */), 0xfffe40ff /* NaN */),
     ((0x50007faa /* 8623401000 */, 0x000011fb /* 6.45e-42 */, 0xff800000 /* -inf */), 0xff800000 /* -inf */),
-    ((0x64007f8b /* 9.481495e+21 */, 0xfa9a8702 /* -4.01176e+35 */, 0xff820000 /* NaN */), 0xff820000 /* NaN */),
-    ((0x6a017faa /* 3.9138577e+25 */, 0x00000070 /* 1.57e-43 */, 0xff80db03 /* NaN */), 0xff80db03 /* NaN */),
-    ((0x6a017faa /* 3.9138577e+25 */, 0x00000070 /* 1.57e-43 */, 0xff80db23 /* NaN */), 0xff80db23 /* NaN */),
+    ((0x64007f8b /* 9.481495e+21 */, 0xfa9a8702 /* -4.01176e+35 */, 0xff820000 /* NaN */), 0xffc20000 /* NaN */),
+    ((0x6a017faa /* 3.9138577e+25 */, 0x00000070 /* 1.57e-43 */, 0xff80db03 /* NaN */), 0xffc0db03 /* NaN */),
+    ((0x6a017faa /* 3.9138577e+25 */, 0x00000070 /* 1.57e-43 */, 0xff80db23 /* NaN */), 0xffc0db23 /* NaN */),
     (
         (0x6e000000 /* 9.9035203e+27 */, 0xdf008000 /* -9259401000000000000 */, 0x7f800000 /* inf */),
         0x7f800000, /* inf */
@@ -90,7 +90,7 @@ pub const FUZZ_IEEE32_FMA_CASES_WITH_EXPECTED_OUTPUTS: &[((u32, u32, u32), u32)]
     ),
     (
         (0xdf0603ff /* -9656842000000000000 */, 0x808000ff /* -1.1755301e-38 */, 0xff9b0000 /* NaN */),
-        0xff9b0000, /* NaN */
+        0xffdb0000, /* NaN */
     ),
     (
         (
@@ -232,7 +232,7 @@ pub const FUZZ_IEEE64_FMA_CASES_WITH_EXPECTED_OUTPUTS: &[((u64, u64, u64), u64)]
             0xffd8000000000000, /* -6.741349255733685e+307 */
             0xfff0001000000000, /* NaN */
         ),
-        0xfff0001000000000, /* NaN */
+        0xfff8001000000000, /* NaN */
     ),
     (
         (
@@ -240,7 +240,7 @@ pub const FUZZ_IEEE64_FMA_CASES_WITH_EXPECTED_OUTPUTS: &[((u64, u64, u64), u64)]
             0xfbd8000000000000, /* -3.6544927542749997e+288 */
             0xfff0ff1000000000, /* NaN */
         ),
-        0xfff0ff1000000000, /* NaN */
+        0xfff8ff1000000000, /* NaN */
     ),
     (
         (
@@ -328,7 +328,7 @@ pub const FUZZ_IEEE64_FMA_CASES_WITH_EXPECTED_OUTPUTS: &[((u64, u64, u64), u64)]
             0x00bc000000004000, /* 3.987332354453194e-305 */
             0xfff0000000e20000, /* NaN */
         ),
-        0xfff0000000e20000, /* NaN */
+        0xfff8000000e20000, /* NaN */
     ),
     (
         (

--- a/tests/ieee.rs
+++ b/tests/ieee.rs
@@ -861,6 +861,20 @@ fn from_decimal_string() {
 }
 
 #[test]
+fn from_to_string_specials() {
+    assert_eq!("+Inf", "+Inf".parse::<Double>().unwrap().to_string());
+    assert_eq!("+Inf", "INFINITY".parse::<Double>().unwrap().to_string());
+    assert_eq!("+Inf", "inf".parse::<Double>().unwrap().to_string());
+    assert_eq!("-Inf", "-Inf".parse::<Double>().unwrap().to_string());
+    assert_eq!("-Inf", "-INFINITY".parse::<Double>().unwrap().to_string());
+    assert_eq!("-Inf", "-inf".parse::<Double>().unwrap().to_string());
+    assert_eq!("NaN", "NaN".parse::<Double>().unwrap().to_string());
+    assert_eq!("NaN", "nan".parse::<Double>().unwrap().to_string());
+    assert_eq!("NaN", "-NaN".parse::<Double>().unwrap().to_string());
+    assert_eq!("NaN", "-nan".parse::<Double>().unwrap().to_string());
+}
+
+#[test]
 fn from_hexadecimal_string() {
     assert_eq!(1.0, "0x1p0".parse::<Double>().unwrap().to_f64());
     assert_eq!(1.0, "+0x1p0".parse::<Double>().unwrap().to_f64());
@@ -3189,5 +3203,19 @@ fn modulo() {
         let f2 = "1.0".parse::<Double>().unwrap();
         assert!(unpack!(status=, f1 % f2).is_nan());
         assert_eq!(status, Status::INVALID_OP);
+    }
+    {
+        let f1 = "-4.0".parse::<Double>().unwrap();
+        let f2 = "-2.0".parse::<Double>().unwrap();
+        let expected = "-0.0".parse::<Double>().unwrap();
+        assert!(unpack!(status=, f1 % f2).bitwise_eq(expected));
+        assert_eq!(status, Status::OK);
+    }
+    {
+        let f1 = "-4.0".parse::<Double>().unwrap();
+        let f2 = "2.0".parse::<Double>().unwrap();
+        let expected = "-0.0".parse::<Double>().unwrap();
+        assert!(unpack!(status=, f1 % f2).bitwise_eq(expected));
+        assert_eq!(status, Status::OK);
     }
 }


### PR DESCRIPTION
*Note: I've had these in separate branches, then in one branch, but I think it's best to submit these as a PR for ease of linking and discussion.*

#### Licensing note: first two "advance" commits are <ins>*pre*-LLVM-relicensing</ins>, the rest are *after*.

---

*Note: this is a copy of the relevant parts of my update comment (https://github.com/rust-lang/rust/issues/55993#issuecomment-1633772225).*

### Quick rundown of notable commits:
* **Advance the port to https://github.com/llvm/llvm-project/commit/768d6dd08783440606da83dac490889329619898** (Dec 2017)
  * this fixes https://github.com/rust-lang/rust/issues/102403
    (thanks to upstream fix https://github.com/llvm/llvm-project/commit/f2c2851efe0505328d1f4074b313a2922bcd8f2c)
* **Advance the port to https://github.com/llvm/llvm-project/commit/69f6098e89312b934ed87e4cd3603401a9b436b4** (Dec 2018)
  * not notable because of any Rust issues, but this is the last stretch of `APFloat` changes before the massive LLVM relicensing (https://github.com/llvm/llvm-project/commit/2946cd701067404b99c39fb29dc9c74bd7193eb3) in early 2019
* **Advance the port to https://github.com/llvm/llvm-project/commit/2b6b8cb10c870d64f7cc29d21fc27cef3c7e0056** (Dec 2019)
  * this fixes https://github.com/rust-lang/rust/issues/93224
    (thanks to upstream fix https://github.com/llvm/llvm-project/commit/e62555c129d535d524354351791c5474c9929582)
* **Advance the port to https://github.com/llvm/llvm-project/commit/6dabc38cce73549ed747c537f81f6f4dd79eba39** (Nov 2020)
  * this obsoletes https://github.com/rust-lang/rust/pull/77368
    (as the port now includes https://github.com/llvm/llvm-project/commit/e34bd1e0b03d20a506ada156d87e1b3a96d82fa2 and https://github.com/llvm/llvm-project/commit/149f5b573c79eac0c519ada4d2f7c50e17796cdf without selective backporting)
  * because `rustc_apfloat` doesn't take certain questionable shortcuts, this exposed a testing mistake
    *all the way back from 2013*: https://github.com/llvm/llvm-project/issues/63842
* **Advance the port to https://github.com/llvm/llvm-project/commit/462a31f5a5abb905869ea93cc49b096079b11aa4** (Dec 2022)
  * this fixes https://github.com/rust-lang/rust/issues/113407
    (thanks to upstream fix https://github.com/llvm/llvm-project/commit/ed6c309d4bf60b8a6abcf37a4e9d5b4bef96191b)
* **fuzz: add `bruteforce-tiny` subcommand for exhaustively checking 8-bit formats.**
  * the introduction of 8-bit floating-point formats allowed exhaustive testing which revealed:
    https://github.com/llvm/llvm-project/issues/63895
    * even if this FMA+subnormals bug was found via 8-bit floats, it applies to `f32::mul_add`/`f64::mul_add` (including LLVM constant-folding: a `rustc` build w/ LLVM assertions enabled *will* crash)
    * at least `rustc_apfloat` will always trip the `assert!` but [LLVM can just give wrong results](https://github.com/llvm/llvm-project/issues/63895#issuecomment-1639050715)

At this point I think it's safe to say this version of `rustc_apfloat` is strictly superior to what's in `compiler/rustc_apfloat` right now <sub>(okay, sure, maybe it has more typos, and we still need to bring in @wesleywiser's detailed documentation of all the licensing history, before it can actually be used by anyone)</sub>.