### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["fuzz"]
 
 [workspace.package]
-version = "0.2.0+llvm-462a31f5a5ab"
+version = "0.2.1+llvm-462a31f5a5ab"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 


### PR DESCRIPTION
Bump version from **0.2.0+llvm-462a31f5a5ab** to **0.2.1+llvm-462a31f5a5ab**.
This minor[^1] version contains the changes from #15 by @tgross35, namely

1. a new convenience method `<T: Debug>  StatusAnd::<T>::unwrap(self) -> T` and
2. great improvements to the documentation

Notes: This repo doesn't contain a changelog (yet), hence no changelog entry. Furthermore, the deps haven't been bumped in a while. Lastly, this lib crate doesn't contain a `Cargo.lock` (yet) for historical reasons. Let me know if any of these things are blocking the release.

Would be great if a new release could be cut (GH+crates.io). I don't have the perms as far as I know.
r? @wesleywiser (#9)

[^1]: We're at 0.\*, hence this isn't a patch.