### PR TITLE
Use runtime env in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,7 @@ fn main() {
         });
 
     let expected_version_metadata = format!("+llvm-{}", &llvm_commit_hash[..12]);
-    let actual_version = env!("CARGO_PKG_VERSION");
+    let actual_version = std::env::var("CARGO_PKG_VERSION").expect("no CARGO_PKG_VERSION in env");
     if !actual_version.ends_with(&expected_version_metadata) {
         eprintln!("\nexpected version ending in `{expected_version_metadata}`, found `{actual_version}`\n");
         panic!("failed to validate Cargo package version (see above)");


### PR DESCRIPTION
While `build.rs` runtime and compile-time environment coincide when using cargo, they may not when using other build systems (notably bazel, which is therefore unable to build a project depending on this crate).

As explained in [the docs][], build scripts should get their inputs from the environment at runtime, not during compilation.

Closes https://github.com/rust-lang/rustc_apfloat/issues/22

[the docs]:https://doc.rust-lang.org/cargo/reference/build-scripts.html#inputs-to-the-build-script