### PR TITLE
Bump to bitflags 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/rust-lang/rustc_apfloat"
 description = "Rust port of C++ llvm::APFloat library"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.6.0"
 smallvec = { version = "1.11.0", features = ["const_generics", "union"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ bitflags! {
     ///    result of an operation that signals the invalid operation exception
     ///    shall be a quiet NaN."
     #[must_use]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
     pub struct Status: u8 {
         const OK = 0x00;
         const INVALID_OP = 0x01;


### PR DESCRIPTION
This is the last crate in rustc that depends on bitflags 1.0