### PR TITLE
fuzz: Replace generated C++ with a source file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target
 /Cargo.lock
+compile_commands.json
+.cache
 
 # Fuzzing data/state.
 /fuzz/in*

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,3 +9,9 @@ afl = "0.15.10"
 clap = { version = "4.1.13", features = ["derive"] }
 num-traits = "0.2.15"
 rustc_apfloat = { path = ".." }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    # Set by the fuzzer
+    'cfg(fuzzing)',
+] }

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -6,10 +6,25 @@ use std::process::{Command, ExitCode};
 
 mod ops;
 
+// NB: Any new symbols exported from the C++ source file need to be listed here,
+// everything else will get pruned.
+const CXX_EXPORTED_SYMBOLS: &[&str] = &[
+    "cxx_apf_eval_op_brainf16",
+    "cxx_apf_eval_op_ieee16",
+    "cxx_apf_eval_op_ieee32",
+    "cxx_apf_eval_op_ieee64",
+    "cxx_apf_eval_op_ieee128",
+    "cxx_apf_eval_op_ppcdoubledouble",
+    "cxx_apf_eval_op_f8e5m2",
+    "cxx_apf_eval_op_f8e4m3fn",
+    "cxx_apf_eval_op_x87_f80",
+];
+
 fn main() -> io::Result<ExitCode> {
-    // HACK(eddyb) disable the default of re-running the build script on *any*
-    // change to *the entire source tree* (i.e. the default is roughly `./`).
-    println!("cargo:rerun-if-changed=build.rs");
+    // Only rerun if sources run by the fuzzer change
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=cxx");
+    println!("cargo::rerun-if-changed=src/apf_fuzz.cpp");
 
     // NOTE(eddyb) `rustc_apfloat`'s own `build.rs` validated the version string.
     let (_, llvm_commit_hash) = env!("CARGO_PKG_VERSION").split_once("+llvm-").unwrap();
@@ -24,12 +39,6 @@ fn main() -> io::Result<ExitCode> {
     if !cxx {
         return Ok(ExitCode::SUCCESS);
     }
-
-    let mut cxx_exported_symbols = vec![];
-    fs::write(
-        out_dir.join("cxx_apf_fuzz.cpp"),
-        ops::generate_cxx(&mut cxx_exported_symbols),
-    )?;
 
     let manifest_dir =
         PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR unset"));
@@ -91,7 +100,7 @@ fn main() -> io::Result<ExitCode> {
         .arg("--include")
         .arg(manifest_dir.join("cxx/fuzz_unity_build.cpp"))
         .arg("--include")
-        .arg(out_dir.join("cxx_apf_fuzz.cpp"))
+        .arg(manifest_dir.join("src/apf_fuzz.cpp"))
         .args(["-c", "-emit-llvm", "-o"])
         .arg(&bc_out);
     println!("+ {clang:?}");
@@ -101,7 +110,7 @@ fn main() -> io::Result<ExitCode> {
     let mut opt = Command::new("opt");
     opt.env_clear()
         .arg("--internalize-public-api-list")
-        .arg(cxx_exported_symbols.join(","))
+        .arg(CXX_EXPORTED_SYMBOLS.join(","))
         .arg(&bc_out)
         .arg("-o")
         .arg(&bc_opt_out);

--- a/fuzz/ops.rs
+++ b/fuzz/ops.rs
@@ -8,13 +8,12 @@
 
 // HACK(eddyb) newtypes to make it easy to tell apart Rust vs C++ specifics.
 struct Rust<T>(T);
-struct Cxx<T>(T);
 
 use self::OpKind::*;
 enum OpKind {
     Unary(char),
     Binary(char),
-    Ternary(Rust<&'static str>, Cxx<&'static str>),
+    Ternary(Rust<&'static str>),
 
     // HACK(eddyb) all other ops have floating-point inputs *and* outputs, so
     // the easiest way to fuzz conversions from/to other types, even if it won't
@@ -58,7 +57,7 @@ const OPS: &[(&str, OpKind)] = &[
     ("Div", Binary('/')),
     ("Rem", Binary('%')),
     // Ternary (`(F, F) -> F`) ops.
-    ("MulAdd", Ternary(Rust("mul_add"), Cxx("fusedMultiplyAdd"))),
+    ("MulAdd", Ternary(Rust("mul_add"))),
     // Roundtrip (`F -> T -> F`) ops.
     ("FToI128ToF", Roundtrip(Type::SInt(128))),
     ("FToU128ToF", Roundtrip(Type::UInt(128))),
@@ -151,7 +150,7 @@ impl<HF> FuzzOp<HF>
         let expr = match kind {
             Unary(op) => format!("{op}{}", inputs[0]),
             Binary(op) => format!("{} {op} {}", inputs[0], inputs[1]),
-            Ternary(Rust(method), _) => {
+            Ternary(Rust(method)) => {
                 format!("{}.{method}({}, {})", inputs[0], inputs[1], inputs[2])
             }
             Roundtrip(ty) => format!(
@@ -186,7 +185,7 @@ impl<F> FuzzOp<F>
         let expr = match kind {
             Unary(op) => format!("{op}{}", inputs[0]),
             Binary(op) => format!("({} {op} {}).value", inputs[0], inputs[1]),
-            Ternary(Rust(method), _) => {
+            Ternary(Rust(method)) => {
                 format!("{}.{method}({}).value", inputs[0], inputs[1..].join(", "))
             }
             Roundtrip(ty @ (Type::SInt(_) | Type::UInt(_))) => {
@@ -223,160 +222,4 @@ impl<F> FuzzOp<F>
         }
     }
 }"
-}
-
-pub fn generate_cxx(exported_symbols: &mut Vec<String>) -> String {
-    String::new()
-        + r#"
-#include <array>
-#include <llvm/ADT/APFloat.h>
-
-using namespace llvm;
-
-#pragma clang diagnostic error "-Wall"
-#pragma clang diagnostic error "-Wextra"
-#pragma clang diagnostic error "-Wunknown-attributes"
-
-using uint128_t = __uint128_t;
-
-template<typename F>
-struct FuzzOp {
-    enum : uint8_t {"#
-        + &all_ops_map_concat(|tag, name, _kind| {
-            format!(
-                "
-        {name} = {tag},"
-            )
-        })
-        + "
-    } tag;
-    F a, b, c;
-
-    F eval() const {
-
-        // HACK(eddyb) 'scratch' variables used by expressions below.
-        APFloat r(0.0);
-        APSInt i;
-        bool scratch_bool;
-
-        switch(tag) {
-            "
-        + &all_ops_map_concat(|_tag, name, kind| {
-            let inputs = kind.inputs(&["a.to_apf()", "b.to_apf()", "c.to_apf()"]);
-            let expr = match kind {
-                // HACK(eddyb) `APFloat` doesn't overload `operator%`, so we have
-                // to go through the `mod` method instead.
-                Binary('%') => format!("((r = {}), r.mod({}), r)", inputs[0], inputs[1]),
-
-                Unary(op) => format!("{op}{}", inputs[0]),
-                Binary(op) => format!("{} {op} {}", inputs[0], inputs[1]),
-
-                Ternary(_, Cxx(method)) => {
-                    format!(
-                        "((r = {}), r.{method}({}, {}, APFloat::rmNearestTiesToEven), r)",
-                        inputs[0], inputs[1], inputs[2]
-                    )
-                }
-
-                Roundtrip(ty @ (Type::SInt(_) | Type::UInt(_))) => {
-                    let (w, signed) = match ty {
-                        Type::SInt(w) => (w, true),
-                        Type::UInt(w) => (w, false),
-                        Type::Float(_) => unreachable!(),
-                    };
-                    format!(
-                        "((r = {}),
-                        (i = APSInt({w}, !{signed})),
-                        r.convertToInteger(i, APFloat::rmTowardZero, &scratch_bool),
-                        r.convertFromAPInt(i, {signed}, APFloat::rmNearestTiesToEven),
-                        r)",
-                        inputs[0]
-                    )
-                }
-                Roundtrip(Type::Float(w)) => {
-                    let cxx_apf_semantics = match w {
-                        32 => "APFloat::IEEEsingle()",
-                        64 => "APFloat::IEEEdouble()",
-                        _ => unreachable!(),
-                    };
-                    format!(
-                        "((r = {input}),
-                        r.convert({cxx_apf_semantics}, APFloat::rmNearestTiesToEven, &scratch_bool),
-                        r.convert({input}.getSemantics(), APFloat::rmNearestTiesToEven, &scratch_bool),
-                        r)",
-                        input = inputs[0]
-                    )
-                }
-            };
-            format!(
-                "
-            case {name}: return F::from_apf({expr});"
-            )
-        })
-        + "
-        }
-    }
-};
-" + &[
-        (16, "IEEEhalf"),
-        (32, "IEEEsingle"),
-        (64, "IEEEdouble"),
-        (128, "IEEEquad"),
-        (16, "BFloat"),
-        (8, "Float8E5M2"),
-        (8, "Float8E4M3FN"),
-        (80, "x87DoubleExtended"),
-    ]
-    .into_iter()
-    .map(|(w, cxx_apf_semantics): (usize, _)| {
-        let uint_width = w.next_power_of_two();
-        let name = match (w, cxx_apf_semantics) {
-            (16, "BFloat") => "BrainF16".into(),
-            (8, s) if s.starts_with("Float8") => s.replace("Float8", "F8"),
-            (80, "x87DoubleExtended") => "X87_F80".into(),
-            _ => {
-                assert!(cxx_apf_semantics.starts_with("IEEE"));
-                format!("IEEE{w}")
-            }
-        };
-        let exported_symbol = format!("cxx_apf_fuzz_eval_op_{}", name.to_ascii_lowercase());
-        exported_symbols.push(exported_symbol.clone());
-        let uint = format!("uint{uint_width}_t");
-        format!(
-            r#"
-struct __attribute__((packed)) {name} {{
-    {uint} bits;
-
-    // HACK(eddyb) these work around `APInt` only being convenient up to 64 bits.
-
-    static {name} from_apf(APFloat apf) {{
-        auto ap_bits = apf.bitcastToAPInt();
-        assert(ap_bits.getBitWidth() == {w});
-
-        {uint} bits = 0;
-        for(int i = 0; i < {w}; i += APInt::APINT_BITS_PER_WORD)
-            bits |= static_cast<{uint}>(
-                ap_bits.getRawData()[i / APInt::APINT_BITS_PER_WORD]
-            ) << i;
-        return {{ bits }};
-    }}
-
-    APFloat to_apf() const {{
-        std::array<
-            APInt::WordType,
-            ({w} + APInt::APINT_BITS_PER_WORD - 1) / APInt::APINT_BITS_PER_WORD
-        > words;
-        for(int i = 0; i < {w}; i += APInt::APINT_BITS_PER_WORD)
-            words[i / APInt::APINT_BITS_PER_WORD] = bits >> i;
-        return APFloat(APFloat::{cxx_apf_semantics}(), APInt({w}, words));
-    }}
-}};
-extern "C" {{
-    void {exported_symbol}({name} *out, FuzzOp<{name}> op) {{
-        *out = op.eval();
-    }}
-}}"#
-        )
-    })
-    .collect::<String>()
 }

--- a/fuzz/src/apf_fuzz.cpp
+++ b/fuzz/src/apf_fuzz.cpp
@@ -1,0 +1,220 @@
+
+#include <array>
+#include <cstdint>
+#include <stdint.h>
+#include <stdio.h>
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/FloatingPointMode.h"
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define rassert(condition,  ...) \
+    if(!__builtin_expect(condition, 1)) { \
+        fprintf(stderr, "assertion `%s` failed at %d: ", STRINGIFY(condition), __LINE__); \
+        fprintf(stderr,  __VA_ARGS__); \
+        fprintf(stderr, "\n"); \
+        exit(1); \
+    }
+
+using namespace llvm;
+
+#pragma clang diagnostic error "-Wall"
+#pragma clang diagnostic error "-Wextra"
+#pragma clang diagnostic error "-Wunknown-attributes"
+
+using uint128_t = __uint128_t;
+
+/** The operation to perform is encoded as a u8 for passing across FFI */
+enum class OpCode: uint8_t {
+    Neg = 0,
+    Add = 1,
+    Sub = 2,
+    Mul = 3,
+    Div = 4,
+    Rem = 5,
+    MulAdd = 6,
+    FToI128ToF = 7,
+    FToU128ToF = 8,
+    FToSingleToF = 9,
+    FToDoubleToF = 10,
+} tag;
+
+
+/** Similarly, rounding mode is passed as a u8 */
+enum class Round: uint8_t {
+  NearestTiesToEven = 0,
+  TowardZero        = 1,
+  TowardPositive    = 2,
+  TowardNegative    = 3,
+  NearestTiesToAway = 4,
+};
+
+/* LLVM uses the following values:
+ * opOK        = 0x00,
+ * opInvalidOp = 0x01,
+ * opDivByZero = 0x02,
+ * opOverflow  = 0x04,
+ * opUnderflow = 0x08,
+ * opInexact   = 0x10
+ */
+using StatusFlags = unsigned;
+
+/** Common operations for a given semantics are grouped in this class */
+template<APFloat::Semantics S, typename U, const unsigned BITS = sizeof(U) * 8>
+class FloatEval {
+public:
+    /** The integer size for passing in FFI (need not be the same size as BITS) */
+    using UInt = U;
+
+    /** Turn an APFloat back into its bitwise representation */
+    static UInt apf_to_bits(APFloat apf) {
+        APInt ap_bits = apf.bitcastToAPInt();
+        unsigned bit_width = ap_bits.getBitWidth();
+        rassert(bit_width == BITS, "%d != %d", bit_width, BITS);
+
+        UInt repr = 0;
+        for (unsigned i = 0; i < BITS; i += APInt::APINT_BITS_PER_WORD) {
+            uint64_t word = ap_bits.getRawData()[i / APInt::APINT_BITS_PER_WORD];
+            repr |= static_cast<UInt>(word) << i;
+        }
+
+        return repr;
+    }
+
+    /** Construct an APFloat from a bitwise representation */
+    static APFloat bits_to_apf(UInt bits) {
+        constexpr int ARR_LEN = (BITS + APInt::APINT_BITS_PER_WORD - 1) /
+                                APInt::APINT_BITS_PER_WORD;
+        std::array<APInt::WordType, ARR_LEN> words;
+        for(unsigned i = 0; i < BITS; i += APInt::APINT_BITS_PER_WORD)
+            words[i / APInt::APINT_BITS_PER_WORD] = bits >> i;
+        APInt i(BITS, words);
+        unsigned int_bits = i.getBitWidth();
+        unsigned sem_size = APFloat::semanticsSizeInBits(getSemantics());
+        rassert(int_bits == sem_size, "%d != %d", int_bits, sem_size);
+        return APFloat(getSemantics(), APInt(BITS, words));
+    }
+
+    /** Evaluate a dynamically specified operation with the given configuration */
+    static StatusFlags eval(OpCode op, Round round, UInt ai, UInt bi,
+                            UInt ci, UInt &out)
+    {
+        APFloat a = bits_to_apf(ai);
+        APFloat b = bits_to_apf(bi);
+        APFloat c = bits_to_apf(ci);
+        APFloat::opStatus status = APFloat::opOK;
+        RoundingMode rm = APFloat::rmNearestTiesToEven;
+        APSInt i;
+        bool cvt_exact = false;
+
+        const fltSemantics& sem = getSemantics();
+        unsigned sem_size = APFloat::semanticsSizeInBits(sem);
+        rassert(sem_size == BITS, "%d != %d", sem_size, BITS);
+
+        switch(round) {
+            case Round::NearestTiesToEven: break;
+            case Round::TowardPositive:
+                rm = APFloat::rmTowardPositive;
+                break;
+            case Round::TowardNegative:
+                rm = APFloat::rmTowardNegative;
+                break;
+            case Round::TowardZero:
+                rm = APFloat::rmTowardZero;
+                break;
+            case Round::NearestTiesToAway:
+                rm = APFloat::rmNearestTiesToAway;
+                break;
+            default:
+                printf("unsupported rounding mode %d\n", rm);
+                exit(1);
+        }
+
+        switch(op) {
+            case OpCode::Neg:
+                a.changeSign();
+                break;
+            case OpCode::Add:
+                status = a.add(b, rm);
+                break;
+            case OpCode::Sub:
+                status = a.subtract(b, rm);
+                break;
+            case OpCode::Mul:
+                status = a.multiply(b, rm);
+                break;
+            case OpCode::Div:
+                status = a.divide(b, rm);
+                break;
+            case OpCode::Rem:
+                status = a.mod(b);
+                break;
+            case OpCode::MulAdd:
+                status = a.fusedMultiplyAdd(b, c, rm);
+                break;
+            /* FIXME: the below operations could be incorrect and are discarding a
+               status, and (though unlikely) could have mistkes that cancel. It would
+               be better to make `out` a u128 and only do a single conversion. */
+            case OpCode::FToI128ToF:
+                i = APSInt(128, false);
+                status = a.convertToInteger(i, rm, &cvt_exact);
+                status = a.convertFromAPInt(i, true, rm);
+                break;
+            case OpCode::FToU128ToF:
+                i = APSInt(128, true);
+                status = a.convertToInteger(i, rm, &cvt_exact);
+                status = a.convertFromAPInt(i, false, rm);
+                break;
+            case OpCode::FToSingleToF:
+                a.convert(APFloat::IEEEsingle(), rm, &cvt_exact);
+                a.convert(sem, rm, &cvt_exact);
+                break;
+            case OpCode::FToDoubleToF:
+                a.convert(APFloat::IEEEsingle(), rm, &cvt_exact);
+                a.convert(sem, rm, &cvt_exact);
+                break;
+            default:
+                printf("unrecognized op tag %d", tag);
+                exit(1);
+        }
+
+        out = apf_to_bits(a);
+        return (StatusFlags)status;
+    }
+
+    static const fltSemantics &getSemantics() {
+        return APFloat::EnumToSemantics(S);
+    }
+};
+
+/* Use the template to produce concrete classes */
+class EvalBrainF16: public FloatEval<APFloat::Semantics::S_BFloat, uint16_t> {};
+class EvalIeee16: public FloatEval<APFloat::Semantics::S_IEEEhalf, uint16_t> {};
+class EvalIeee32: public FloatEval<APFloat::Semantics::S_IEEEsingle, uint32_t> {};
+class EvalIeee64: public FloatEval<APFloat::Semantics::S_IEEEdouble, uint64_t> {};
+class EvalIeee128: public FloatEval<APFloat::Semantics::S_IEEEquad, uint128_t> {};
+class EvalPpcDoubleDouble: public FloatEval<APFloat::Semantics::S_PPCDoubleDouble, uint128_t> {};
+class EvalF8E5M2: public FloatEval<APFloat::Semantics::S_Float8E5M2, uint8_t> {};
+class EvalF8E4M3FN: public FloatEval<APFloat::Semantics::S_Float8E4M3FN, uint8_t> {};
+class EvalX87F80: public FloatEval<APFloat::Semantics::S_x87DoubleExtended, uint128_t, 80> {};
+
+/* And define the ways to invoke them */
+#define MAKE_EXTERN(Ty, name) \
+    StatusFlags name(OpCode op, Round round, Ty::UInt ai, Ty::UInt bi, \
+                     Ty::UInt ci, Ty::UInt &out) { \
+        return Ty::eval(op, round, ai, bi, ci, out); \
+    }
+
+extern "C" {
+    /* NB: Every symbol defined here also needs to be in the list in build.rs */
+    MAKE_EXTERN(EvalBrainF16, cxx_apf_eval_op_brainf16);
+    MAKE_EXTERN(EvalIeee16, cxx_apf_eval_op_ieee16);
+    MAKE_EXTERN(EvalIeee32, cxx_apf_eval_op_ieee32);
+    MAKE_EXTERN(EvalIeee64, cxx_apf_eval_op_ieee64);
+    MAKE_EXTERN(EvalIeee128, cxx_apf_eval_op_ieee128);
+    MAKE_EXTERN(EvalPpcDoubleDouble, cxx_apf_eval_op_ppcdoubledouble);
+    MAKE_EXTERN(EvalF8E5M2, cxx_apf_eval_op_f8e5m2);
+    MAKE_EXTERN(EvalF8E4M3FN, cxx_apf_eval_op_f8e4m3fn);
+    MAKE_EXTERN(EvalX87F80, cxx_apf_eval_op_x87_f80);
+}

--- a/fuzz/src/main.rs
+++ b/fuzz/src/main.rs
@@ -1,7 +1,6 @@
 use clap::{CommandFactory, Parser, Subcommand};
 use rustc_apfloat::Float as _;
 use std::io::Write;
-use std::mem::MaybeUninit;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::{fmt, mem};
@@ -166,15 +165,39 @@ macro_rules! float_reprs {
                     Self(bits.try_into().unwrap())
                 }
 
+                // FIXME: we are discarding status results here and not making use of rounding mode.
                 fn cxx_apf_eval_fuzz_op(op: FuzzOp<Self>) -> Self {
                     extern "C" {
-                        fn $cxx_apf_eval_fuzz_op(out: &mut MaybeUninit<$name>, op: FuzzOp<$name>);
+                        fn $cxx_apf_eval_fuzz_op(
+                            opcode: u8,
+                            round: u8,
+                            ai: $repr,
+                            bi: $repr,
+                            ci: $repr,
+                            out: &mut $repr,
+                        ) -> u32;
                     }
-                    unsafe {
-                        let mut out = MaybeUninit::uninit();
-                        $cxx_apf_eval_fuzz_op(&mut out, op);
-                        out.assume_init()
-                    }
+                    let (ai, bi, ci)= match op {
+                        FuzzOp::Neg(a) => (a.0, 0, 0),
+                        FuzzOp::Add(a, b) => (a.0, b.0, 0),
+                        FuzzOp::Sub(a, b) => (a.0, b.0, 0),
+                        FuzzOp::Mul(a, b) => (a.0, b.0, 0),
+                        FuzzOp::Div(a, b) => (a.0, b.0, 0),
+                        FuzzOp::Rem(a, b) => (a.0, b.0, 0),
+                        FuzzOp::MulAdd(a, b, c) => (a.0, b.0, c.0),
+                        FuzzOp::FToI128ToF(a) => (a.0, 0, 0),
+                        FuzzOp::FToU128ToF(a) => (a.0, 0, 0),
+                        FuzzOp::FToSingleToF(a) => (a.0, 0, 0),
+                        FuzzOp::FToDoubleToF(a) => (a.0, 0, 0),
+                    };
+
+                    let mut out = 0;
+
+                    let _status = unsafe {
+                        $cxx_apf_eval_fuzz_op(op.tag(), 0, ai, bi, ci, &mut out)
+                    };
+
+                    Self(out)
                 }
 
                 fn hard_eval_fuzz_op_if_supported(_op: FuzzOp<Self>) -> Option<Self> {
@@ -209,45 +232,46 @@ macro_rules! float_reprs {
     }
 }
 
+// FIXME: missing PowerPC semantics
 float_reprs! {
     Ieee16(u16) {
         type RustcApFloat = rustc_apfloat::ieee::Half;
-        extern fn = cxx_apf_fuzz_eval_op_ieee16;
+        extern fn = cxx_apf_eval_op_ieee16;
     }
     Ieee32(u32) {
         type RustcApFloat = rustc_apfloat::ieee::Single;
-        extern fn = cxx_apf_fuzz_eval_op_ieee32;
+        extern fn = cxx_apf_eval_op_ieee32;
         type HardFloat = f32;
     }
     Ieee64(u64) {
         type RustcApFloat = rustc_apfloat::ieee::Double;
-        extern fn = cxx_apf_fuzz_eval_op_ieee64;
+        extern fn = cxx_apf_eval_op_ieee64;
         type HardFloat = f64;
     }
     Ieee128(u128) {
         type RustcApFloat = rustc_apfloat::ieee::Quad;
-        extern fn = cxx_apf_fuzz_eval_op_ieee128;
+        extern fn = cxx_apf_eval_op_ieee128;
     }
 
     // Non-standard IEEE-like formats.
     F8E5M2(u8) {
         type RustcApFloat = rustc_apfloat::ieee::Float8E5M2;
         const REPR_TAG = 8 + 0;
-        extern fn = cxx_apf_fuzz_eval_op_f8e5m2;
+        extern fn = cxx_apf_eval_op_f8e5m2;
     }
     F8E4M3FN(u8) {
         type RustcApFloat = rustc_apfloat::ieee::Float8E4M3FN;
         const REPR_TAG = 8 + 1;
-        extern fn = cxx_apf_fuzz_eval_op_f8e4m3fn;
+        extern fn = cxx_apf_eval_op_f8e4m3fn;
     }
     BrainF16(u16) {
         type RustcApFloat = rustc_apfloat::ieee::BFloat;
         const REPR_TAG = 16 + 1;
-        extern fn = cxx_apf_fuzz_eval_op_brainf16;
+        extern fn = cxx_apf_eval_op_brainf16;
     }
     X87_F80(u128) {
         type RustcApFloat = rustc_apfloat::ieee::X87DoubleExtended;
-        extern fn = cxx_apf_fuzz_eval_op_x87_f80;
+        extern fn = cxx_apf_eval_op_x87_f80;
     }
 }
 


### PR DESCRIPTION
This is easier to read and allows for some cleanup. As part of this,
switch from passing packed structures back and forth to passing integers
as separate arguments to be more certain about FFI-safety, rather than
passing a Rust enum.

This will also allow us to fuzz with rounding modes and verifying status
in the future.