### PR TITLE
fuzz: Improve flexibility of the fuzz binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ allocating to handle the arbitrary precision needed for conversions to/from deci
 
 However, that port had a fatal flaw: it was added to the `rust-lang/rust` repository
 without its unique licensing status (as a port of a C++ library with its own license)
-being properly tracked, communicated, taken into account, etc.  
+being properly tracked, communicated, taken into account, etc.
 The end result was years of limbo, mostly chronicled in the Rust issue
 [`rust-lang/rust#55993`](https://github.com/rust-lang/rust/issues/55993), in which
 the in-tree port couldn't really receive proper updated or even maintenance, due
@@ -28,39 +28,39 @@ due to its unclear status.
 
 This repository (`rust-lang/rustc_apfloat`) is the result of a 2022 plan on
 [the relevant Zulip topic](https://rust-lang.zulipchat.com/#narrow/stream/231349-t-core.2Flicensing/topic/apfloat), fully put into motion during 2023:
-* the `git` history of the in-tree `compiler/rustc_apfloat` library was extracted  
+* the `git` history of the in-tree `compiler/rustc_apfloat` library was extracted
   (see the separate [`rustc_apfloat-git-history-extraction`](https://github.com/LykenSol/rustc_apfloat-git-history-extraction) repository for more details)
 * only commits that were *both* necessary *and* had clear copyright status, were kept
-* any missing functionality or bug fixes, would have to be either be re-contributed,  
+* any missing functionality or bug fixes, would have to be either be re-contributed,
   or rebuilt from the ground up (mostly the latter ended up being done, see below)
 
 Most changes since the original port had been aesthetic (e.g. spell-checking, `rustfmt`),
 so little was lost in the process.
 
 Starting from that much smaller "trusted" base:
-* everything could use LLVM's new (since 2019) license, "`Apache-2.0 WITH LLVM-exception`"  
+* everything could use LLVM's new (since 2019) license, "`Apache-2.0 WITH LLVM-exception`"
   (see the ["Licensing"](#licensing) section below and/or [LICENSE-DETAILS.md](./LICENSE-DETAILS.md) for more details)
 * new facilities were built (benchmarks, and [a fuzzer comparing Rust/C++/hardware](#fuzzing))
 * excessive testing was performed (via a combination of fuzzing and bruteforce search)
 * latent bugs were discovered (e.g. LLVM issues
 [#63895](https://github.com/llvm/llvm-project/issues/63895) and
 [#63938](https://github.com/llvm/llvm-project/issues/63938))
-* the port has been forwarded in time, to include upstream (`llvm/llvm-project`) changes   
+* the port has been forwarded in time, to include upstream (`llvm/llvm-project`) changes
   to `llvm::APFloat` over the years (since 2017), removing the need for selective backports
 
 ## Versioning
 
-As this is, for the time being, a "living port", tracking upstream (`llvm/llvm-project`)  
+As this is, for the time being, a "living port", tracking upstream (`llvm/llvm-project`)
 `llvm::APFloat` changes, the `rustc_apfloat` crate will have versions of the form:
 
 ```
 0.X.Y+llvm-ZZZZZZZZZZZZ
 ```
-* `X` is always bumped after semver-incompatible API changes,  
+* `X` is always bumped after semver-incompatible API changes,
   or when updating the upstream (`llvm/llvm-project`) commit the port is based on
 * `Y` is only bumped when other parts of the version don't need to be (e.g. for bug fixes)
-* `+llvm-ZZZZZZZZZZZZ` is ["version metadata"](https://doc.rust-lang.org/cargo/reference/resolver.html#version-metadata) (which Cargo itself ignores),  
-  and `ZZZZZZZZZZZZ` always holds the first 12 hexadecimal digits of  
+* `+llvm-ZZZZZZZZZZZZ` is ["version metadata"](https://doc.rust-lang.org/cargo/reference/resolver.html#version-metadata) (which Cargo itself ignores),
+  and `ZZZZZZZZZZZZ` always holds the first 12 hexadecimal digits of
   the upstream (`llvm/llvm-project`) `git` commit hash the port is based on
 
 
@@ -84,7 +84,7 @@ involves an automated build of the original C++ `llvm::APFloat` code with `clang
 Rust code), and has been prototyped and tested on Linux (and is unlikely to work
 on other platforms, or even some Linux distros, though it mostly assumes UNIX).
 
-Example usage:  
+Example usage:
 <sub>(**TODO**: maybe move this to `fuzz/README.md` and/or expand on it)</sub>
 
 ```sh
@@ -103,10 +103,15 @@ cargo afl fuzz -i fuzz/in-foo -o fuzz/out-foo target/release/rustc_apfloat-fuzz
 ```
 
 To visualize the fuzzing testcases, you can use the `decode` subcommand:
+
 ```sh
 cargo run -p rustc_apfloat-fuzz decode fuzz/out-foo/default/crashes/*
 ```
-(this will work even while `cargo afl fuzz`, i.e. AFL++, is running)
+
+Note that `cargo run` and `cargo afl build` conflict, so if running the fuzzer
+and then decoding with the same debug/release setting, this will always trigger
+a rebuild. In these cases, launching the binary directly to call `decode` can
+avoid the extra builds.
 
 ## Licensing
 

--- a/etc/fuzz-parallel.sh
+++ b/etc/fuzz-parallel.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Launch the fuzzer with multiple parallel jobs. Requires tmux.
+#
+# Taken from: <https://github.com/rust-fuzz/afl.rs/issues/132#issuecomment-997827086>
+
+set -euxo pipefail
+
+# Detect cores
+all_cores="$(nproc)"
+used_cores="$((all_cores - 2))"
+in_dir="target/fuzz-in"
+sync_dir="target/fuzz-out"
+tmux_window=afl
+
+if [[ "$used_cores" -lt 2 ]]; then
+    echo "Error: used_cores < 2"
+    exit 1
+fi
+
+function print_usage() {
+    set +x
+    echo "Usage: $0 [-j PROCS]"
+    echo ""
+    echo "Options:"
+    echo "  -o DIR      Output directory"
+    echo "  -j PROCS    Number of parallel jobs to use (default: $used_cores)"
+    echo "  -h,--help   Print this help and exit"
+    set -x
+}
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -j) used_cores="$2"; shift ;;
+        -o) sync_dir="$2"; shift ;;
+        -h|--help) print_usage; exit 0 ;;
+    esac
+    shift
+done
+
+echo "Using $used_cores out of $all_cores cores"
+
+
+# Make sure we have at least one input file
+mkdir -p "$in_dir"
+echo > "$in_dir/empty"
+
+# Start main node
+tmux new -d -s "afl01" -n $tmux_window \
+    "cargo afl fuzz -i $in_dir -o $sync_dir -M fuzzer01 target/release/rustc_apfloat-fuzz"
+echo "Spawned main instance afl01"
+
+# Start secondary instances
+for i in $(seq -f "%02.0f" 2 "$used_cores"); do
+    tmux new -d -s "afl$i" -n $tmux_window \
+        cargo afl fuzz -i $in_dir -o "$sync_dir" -S "fuzzer$i" target/release/rustc_apfloat-fuzz
+    echo "Spawned secondary instance afl$i"
+done
+
+set +x
+
+# Show status output
+echo ""
+echo "Tmux sessions:"
+tmux ls | grep afl
+echo ""
+echo "Tmux cheatsheet (shell):"
+echo "  Attach:"
+echo "    tmux attach -t afl01"
+echo "  Kill all sessions:"
+echo "    tmux kill-server"
+echo ""
+echo "Tmux chatsheet (inside tmux):"
+echo "  List sessions:"
+echo "    Ctrl-b s"
+echo "  Switch to next session:"
+echo "    Ctrl-b )"
+echo "  Switch to prev session:"
+echo "    Ctrl-b ("
+echo "  Detach:"
+echo "    Ctrl-b d"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,4 +14,7 @@ rustc_apfloat = { path = ".." }
 unexpected_cfgs = { level = "warn", check-cfg = [
     # Set by the fuzzer
     'cfg(fuzzing)',
+    # Unstable configs
+    'cfg(target_has_reliable_f16)',
+    'cfg(target_has_reliable_f128)',
 ] }

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 // NB: Any new symbols exported from the C++ source file need to be listed here,
 // everything else will get pruned.
 const CXX_EXPORTED_SYMBOLS: &[&str] = &[
+    "check_error",
     "cxx_apf_eval_op_brainf16",
     "cxx_apf_eval_op_ieee16",
     "cxx_apf_eval_op_ieee32",

--- a/fuzz/src/apf_fuzz.cpp
+++ b/fuzz/src/apf_fuzz.cpp
@@ -1,6 +1,7 @@
 
 #include <array>
 #include <cstdint>
+#include <string.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "llvm/ADT/APFloat.h"
@@ -43,11 +44,11 @@ enum class OpCode: uint8_t {
 
 /** Similarly, rounding mode is passed as a u8 */
 enum class Round: uint8_t {
-  NearestTiesToEven = 0,
-  TowardZero        = 1,
-  TowardPositive    = 2,
-  TowardNegative    = 3,
-  NearestTiesToAway = 4,
+    NearestTiesToEven = 0,
+    TowardZero        = 1,
+    TowardPositive    = 2,
+    TowardNegative    = 3,
+    NearestTiesToAway = 4,
 };
 
 /* LLVM uses the following values:
@@ -57,8 +58,23 @@ enum class Round: uint8_t {
  * opOverflow  = 0x04,
  * opUnderflow = 0x08,
  * opInexact   = 0x10
+ *
+ * We also use -1 to indicate an exception.
  */
-using StatusFlags = unsigned;
+using StatusFlags = int32_t;
+
+/* Utilities for making C++ exceptions FFI-safe */
+thread_local const char *AP_ERROR = NULL;
+
+StatusFlags handle_std_exception(const std::exception& e) {
+    AP_ERROR = strdup(e.what());
+    return -1;
+}
+
+StatusFlags handle_unknown_exception() {
+    AP_ERROR = "Unknown exception";
+    return -1;
+}
 
 /** Common operations for a given semantics are grouped in this class */
 template<APFloat::Semantics S, typename U, const unsigned BITS = sizeof(U) * 8>
@@ -96,8 +112,7 @@ public:
         return APFloat(getSemantics(), APInt(BITS, words));
     }
 
-    /** Evaluate a dynamically specified operation with the given configuration */
-    static StatusFlags eval(OpCode op, Round round, UInt ai, UInt bi,
+    static StatusFlags eval_impl(OpCode op, Round round, UInt ai, UInt bi,
                             UInt ci, UInt &out)
     {
         APFloat a = bits_to_apf(ai);
@@ -154,7 +169,7 @@ public:
                 status = a.fusedMultiplyAdd(b, c, rm);
                 break;
             /* FIXME: the below operations could be incorrect and are discarding a
-               status, and (though unlikely) could have mistkes that cancel. It would
+               status, and (though unlikely) could have mistakes that cancel. It would
                be better to make `out` a u128 and only do a single conversion. */
             case OpCode::FToI128ToF:
                 i = APSInt(128, false);
@@ -171,7 +186,7 @@ public:
                 a.convert(sem, rm, &cvt_exact);
                 break;
             case OpCode::FToDoubleToF:
-                a.convert(APFloat::IEEEsingle(), rm, &cvt_exact);
+                a.convert(APFloat::IEEEdouble(), rm, &cvt_exact);
                 a.convert(sem, rm, &cvt_exact);
                 break;
             default:
@@ -181,6 +196,24 @@ public:
 
         out = apf_to_bits(a);
         return (StatusFlags)status;
+    }
+
+    /** Evaluate a dynamically specified operation with the given configuration */
+    /* FIXME(perf): since some of these may allocate, we should have an init
+     * function to prealloc, then pass a pointer to this call. */
+    static StatusFlags eval(OpCode op, Round round, UInt ai, UInt bi,
+                            UInt ci, UInt &out) {
+#if __cpp_exceptions
+        try {
+            return eval_impl(op, round, ai, bi, ci, out);
+        } catch (const std::exception& e) {
+            return handle_std_exception(e);
+        } catch(...) {
+            return handle_unknown_exception();
+        }
+#else
+        return eval_impl(op, round, ai, bi, ci, out);
+#endif
     }
 
     static const fltSemantics &getSemantics() {
@@ -206,8 +239,13 @@ class EvalX87F80: public FloatEval<APFloat::Semantics::S_x87DoubleExtended, uint
         return Ty::eval(op, round, ai, bi, ci, out); \
     }
 
+/* NB: Every symbol defined here also needs to be in the list in build.rs, otherwise they
+ * will get pruned during optimization. */
 extern "C" {
-    /* NB: Every symbol defined here also needs to be in the list in build.rs */
+    const char *check_error() {
+        return AP_ERROR;
+    }
+
     MAKE_EXTERN(EvalBrainF16, cxx_apf_eval_op_brainf16);
     MAKE_EXTERN(EvalIeee16, cxx_apf_eval_op_ieee16);
     MAKE_EXTERN(EvalIeee32, cxx_apf_eval_op_ieee32);

--- a/fuzz/src/apf_fuzz.rs
+++ b/fuzz/src/apf_fuzz.rs
@@ -73,6 +73,70 @@ impl<T> FuzzOp<T> {
     }
 }
 
+/// A testable operation, which can be encoded as a byte.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Op {
+    Neg = 0,
+    Add = 1,
+    Sub = 2,
+    Mul = 3,
+    Div = 4,
+    Rem = 5,
+    MulAdd = 6,
+    FToI128ToF = 7,
+    FToU128ToF = 8,
+    FToSingleToF = 9,
+    FToDoubleToF = 10,
+}
+
+impl Op {
+    pub fn from_u8(tag: u8) -> Option<Self> {
+        let v = match tag {
+            x if x == Self::Neg.to_u8() => Self::Neg,
+            x if x == Self::Add.to_u8() => Self::Add,
+            x if x == Self::Sub.to_u8() => Self::Sub,
+            x if x == Self::Mul.to_u8() => Self::Mul,
+            x if x == Self::Div.to_u8() => Self::Div,
+            x if x == Self::Rem.to_u8() => Self::Rem,
+            x if x == Self::MulAdd.to_u8() => Self::MulAdd,
+            x if x == Self::FToI128ToF.to_u8() => Self::FToI128ToF,
+            x if x == Self::FToU128ToF.to_u8() => Self::FToU128ToF,
+            x if x == Self::FToSingleToF.to_u8() => Self::FToSingleToF,
+            x if x == Self::FToDoubleToF.to_u8() => Self::FToDoubleToF,
+            _ => return None,
+        };
+        Some(v)
+    }
+
+    pub fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    pub fn airity(self) -> Arity {
+        match self {
+            Op::Neg => Arity::Unary,
+            Op::Add => Arity::Binary,
+            Op::Sub => Arity::Binary,
+            Op::Mul => Arity::Binary,
+            Op::Div => Arity::Binary,
+            Op::Rem => Arity::Binary,
+            Op::MulAdd => Arity::Ternary,
+            Op::FToI128ToF => Arity::Unary,
+            Op::FToU128ToF => Arity::Unary,
+            Op::FToSingleToF => Arity::Unary,
+            Op::FToDoubleToF => Arity::Unary,
+        }
+    }
+}
+
+/// Number of inputs to an operation.
+#[derive(Copy, Clone, Debug)]
+pub enum Arity {
+    Unary = 1,
+    Binary = 2,
+    Ternary = 3,
+}
+
 impl<HF> FuzzOp<HF>
 where
     HF: num_traits::Float

--- a/fuzz/src/main.rs
+++ b/fuzz/src/main.rs
@@ -1,12 +1,22 @@
+#![feature(f16)]
+#![feature(f128)]
+#![allow(internal_features)] // for the below config
+#![feature(cfg_target_has_reliable_f16_f128)]
+
 mod apf_fuzz;
 mod exhaustive;
 
 use apf_fuzz::FuzzOp;
 use clap::{CommandFactory, Parser, Subcommand};
-use rustc_apfloat::Float as _;
-use std::fmt;
+use io::IsTerminal;
+use rustc_apfloat::ieee::{Double, Single};
+use rustc_apfloat::{Float, FloatConvert, Round, Status, StatusAnd, ieee};
+use std::io::{self, Read};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
+use std::{fmt, fs};
+
+use crate::apf_fuzz::Op;
 
 #[derive(Clone, Parser, Debug)]
 struct Args {
@@ -40,6 +50,11 @@ struct Args {
 
 #[derive(Clone, Subcommand, Debug)]
 enum Commands {
+    /// Check the input from stdin similar to what the fuzzer will run
+    Check {
+        /// The file to check. If unspecified or `-`, read from stdin.
+        file: Option<PathBuf>,
+    },
     /// Decode fuzzing in/out testcases (binary serialized `FuzzOp`s)
     Decode { files: Vec<PathBuf> },
 
@@ -76,16 +91,20 @@ enum Commands {
 /// Because of the C++ interop (exposed via the `cxx_apf_eval_fuzz_op` method),
 /// all types implementing this trait *must* be annotated with `#[repr(C, packed)]`,
 /// and `ops.rs` *must* also ensure exactly matching layout for the C++ counterpart.
-trait FloatRepr: Copy + Default + Eq + fmt::Display {
-    type RustcApFloat: rustc_apfloat::Float
-        + rustc_apfloat::Float
-        + rustc_apfloat::FloatConvert<rustc_apfloat::ieee::Single>
-        + rustc_apfloat::FloatConvert<rustc_apfloat::ieee::Double>;
+trait FloatRepr: Copy + Default + Eq + fmt::Display + fmt::Debug {
+    type RustcApFloat: Float + FloatConvert<ieee::Single> + FloatConvert<ieee::Double> + fmt::Debug;
+    type Repr;
 
     const BIT_WIDTH: usize = Self::RustcApFloat::BITS;
     const BYTE_LEN: usize = (Self::BIT_WIDTH + 7) / 8;
 
+    // Eventually we will have assembly implementations.
+    const HOST_SUPPORTS_FP_ENV: bool = false;
+
     const NAME: &'static str;
+
+    #[cfg_attr(not(test), expect(dead_code))]
+    const KIND: FpKind;
 
     // HACK(eddyb) this has to be overwritable because we have more than one
     // format with the same `BIT_WIDTH`, so it's not unambiguous on its own.
@@ -95,7 +114,10 @@ trait FloatRepr: Copy + Default + Eq + fmt::Display {
         Self::NAME.to_ascii_lowercase().replace("ieee", "f")
     }
 
-    // FIXME(eddyb) these should ideally be using `[u8; Self::BYTE_LEN]`.
+    fn to_ap(self) -> Self::RustcApFloat;
+    fn from_ap(x: Self::RustcApFloat) -> Self;
+
+    // FIXME(const) `[u8; Self::BYTE_LEN]` would be better but requires MGCA.
     fn from_le_bytes(bytes: &[u8]) -> Self;
     fn write_as_le_bytes_into(self, out_bytes: &mut Vec<u8>);
 
@@ -104,14 +126,22 @@ trait FloatRepr: Copy + Default + Eq + fmt::Display {
 
     // HACK(eddyb) this avoids needing another trait (or an `enum` of all formats).
     fn cxx_apf_eval_fuzz_op(op: FuzzOp<Self>) -> Self;
+    fn cxx_apf_eval_fuzz_op2(op: Op, rm: Round, a: Self, b: Self, c: Self) -> StatusAnd<Self>;
     // HACK(eddyb) this avoids dealing with separate traits and other complications.
     fn hard_eval_fuzz_op_if_supported(op: FuzzOp<Self>) -> Option<Self>;
+    fn host_eval_fuzz_op_if_supported2(
+        op: Op,
+        rm: Round,
+        a: Self,
+        b: Self,
+        c: Self,
+    ) -> Option<StatusAnd<Self>>;
 }
 
 macro_rules! float_reprs {
     ($($name:ident($repr:ty) {
         type RustcApFloat = $rs_apf_ty:ty;
-        $(const REPR_TAG = $repr_tag:expr;)?
+        const REPR_TAG = $repr_tag:expr;
         extern fn = $cxx_apf_eval_fuzz_op:ident;
         $(type HardFloat = $hard_float_ty:ty;)?
     })+) => {
@@ -131,20 +161,47 @@ macro_rules! float_reprs {
             }
         }
 
+        #[allow(non_camel_case_types)]
+        #[derive(Clone, Copy, Debug, PartialEq)]
+        enum FpKind {
+            $($name = $repr_tag,)+
+        }
+
+        impl FpKind {
+            fn from_u8(tag: u8) -> Option<Self> {
+                let v = match tag {
+                    $(x if x == Self::$name.to_u8() => Self::$name,)+
+                    _ => return None,
+                };
+                Some(v)
+            }
+
+            fn to_u8(self) -> u8 {
+                self as u8
+            }
+        }
+
         $(
-            // HACK(eddyb) `packed` is here becasue `u128` alignment can differ
-            // from `__uint128_t` alignment, on some platforms, and it's better
-            // to just get rid of alignment sources entirely.
-            #[repr(C, packed)]
+            #[repr(C)]
             #[derive(Copy, Clone, Default, PartialEq, Eq)]
             struct $name($repr);
 
             impl FloatRepr for $name {
                 type RustcApFloat = $rs_apf_ty;
+                type Repr = $repr;
 
                 const NAME: &'static str = stringify!($name);
+                const KIND: FpKind = FpKind::$name;
 
-                $(const REPR_TAG: u8 = $repr_tag;)?
+                const REPR_TAG: u8 = $repr_tag;
+
+                fn to_ap(self) -> Self::RustcApFloat {
+                    Self::RustcApFloat::from_bits(self.to_bits_u128())
+                }
+
+                fn from_ap(x: Self::RustcApFloat) -> Self {
+                    Self::from_bits_u128(x.to_bits())
+                }
 
                 fn from_le_bytes(bytes: &[u8]) -> Self {
                     // HACK(eddyb) this allows using e.g. `u128` to hold 80 bits.
@@ -167,17 +224,6 @@ macro_rules! float_reprs {
 
                 // FIXME: we are discarding status results here and not making use of rounding mode.
                 fn cxx_apf_eval_fuzz_op(op: FuzzOp<Self>) -> Self {
-                    // SAFETY: matches definition in `ap_fuzz.cpp`
-                    unsafe extern "C" {
-                        safe fn $cxx_apf_eval_fuzz_op(
-                            opcode: u8,
-                            round: u8,
-                            ai: $repr,
-                            bi: $repr,
-                            ci: $repr,
-                            out: &mut $repr,
-                        ) -> u32;
-                    }
                     let (ai, bi, ci)= match op {
                         FuzzOp::Neg(a) => (a.0, 0, 0),
                         FuzzOp::Add(a, b) => (a.0, b.0, 0),
@@ -193,14 +239,42 @@ macro_rules! float_reprs {
                     };
 
                     let mut out = 0;
-                    let _status = $cxx_apf_eval_fuzz_op(op.tag(), 0, ai, bi, ci, &mut out);
+                    let _status = cxx::$cxx_apf_eval_fuzz_op(op.tag(), 0, ai, bi, ci, &mut out);
                     Self(out)
+                }
+
+                fn cxx_apf_eval_fuzz_op2(
+                    op: Op, rm: Round, a: Self, b: Self, c: Self
+                ) -> StatusAnd<Self>
+                {
+
+                    let rm = round_to_u8(rm);
+                    let mut out = 0;
+                    let status = cxx::$cxx_apf_eval_fuzz_op(op.to_u8(), rm, a.0, b.0, c.0, &mut out);
+                    let status = cxx::decode_status(status);
+
+                    status.and(Self(out))
                 }
 
                 fn hard_eval_fuzz_op_if_supported(_op: FuzzOp<Self>) -> Option<Self> {
                     None $(.or(Some(
                         Self(_op.map(|Self(x)| <$hard_float_ty>::from_bits(x)).eval_hard().to_bits())
                     )))?
+                }
+
+                #[allow(unused_variables)]
+                fn host_eval_fuzz_op_if_supported2(
+                    op: Op, rm: Round, a: Self, b: Self, c: Self
+                ) -> Option<StatusAnd<Self>> {
+                    None $(.or(
+                        Some(eval_host::<$hard_float_ty>(op, rm, a.0, b.0, c.0)?.map(Self))
+                    ))?
+                }
+            }
+
+            impl fmt::Debug for $name {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    write!(f, "{:#0width$x}", self.0, width=(Self::BIT_WIDTH / 4))
                 }
             }
 
@@ -214,7 +288,7 @@ macro_rules! float_reprs {
                 // printing bug specific to `rustc_apfloat`, but we only use
                 // this for printing the "human-friendly" representation, with
                 // the underlying bit-pattern being the actual trusted value.
-                <Self as FloatRepr>::RustcApFloat::from_bits(self.to_bits_u128()).fmt(f)
+                self.to_ap().fmt(f)
             }
         }
     };
@@ -233,20 +307,24 @@ macro_rules! float_reprs {
 float_reprs! {
     Ieee16(u16) {
         type RustcApFloat = rustc_apfloat::ieee::Half;
+        const REPR_TAG = 16;
         extern fn = cxx_apf_eval_op_ieee16;
     }
     Ieee32(u32) {
         type RustcApFloat = rustc_apfloat::ieee::Single;
+        const REPR_TAG = 32;
         extern fn = cxx_apf_eval_op_ieee32;
         type HardFloat = f32;
     }
     Ieee64(u64) {
         type RustcApFloat = rustc_apfloat::ieee::Double;
+        const REPR_TAG = 64;
         extern fn = cxx_apf_eval_op_ieee64;
         type HardFloat = f64;
     }
     Ieee128(u128) {
         type RustcApFloat = rustc_apfloat::ieee::Quad;
+        const REPR_TAG = 128;
         extern fn = cxx_apf_eval_op_ieee128;
     }
 
@@ -268,6 +346,7 @@ float_reprs! {
     }
     X87_F80(u128) {
         type RustcApFloat = rustc_apfloat::ieee::X87DoubleExtended;
+        const REPR_TAG = 80;
         extern fn = cxx_apf_eval_op_x87_f80;
     }
 }
@@ -290,29 +369,9 @@ impl<F: FloatRepr> FuzzOpEvalOutputs<F> {
 impl<F: FloatRepr> FuzzOp<F>
 // FIXME(eddyb) such bounds shouldn't be here, but `FloatRepr` can't imply them.
 where
-    rustc_apfloat::ieee::Single: rustc_apfloat::FloatConvert<F::RustcApFloat>,
-    rustc_apfloat::ieee::Double: rustc_apfloat::FloatConvert<F::RustcApFloat>,
+    ieee::Single: FloatConvert<F::RustcApFloat>,
+    ieee::Double: FloatConvert<F::RustcApFloat>,
 {
-    fn try_decode(data: &[u8]) -> Result<Self, ()> {
-        let (&tag, inputs) = data.split_first().ok_or(())?;
-        if inputs.len() % F::BYTE_LEN != 0 {
-            return Err(());
-        }
-
-        let mut inputs = inputs.chunks(F::BYTE_LEN).map(F::from_le_bytes);
-        let mut too_few_inputs = false;
-        let op = FuzzOp::from_tag(tag).ok_or(())?.map(|()| {
-            inputs.next().unwrap_or_else(|| {
-                too_few_inputs = true;
-                F::default()
-            })
-        });
-        if too_few_inputs || inputs.next().is_some() {
-            return Err(());
-        }
-        Ok(op)
-    }
-
     // FIXME(eddyb) add `seed` subcommand using this method, and a set
     // of basic examples, e.g. every `FuzzOp` variant with `0.0` for all inputs
     // (and/or maybe testcases from known and/or fixed bugs, too).
@@ -445,34 +504,6 @@ where
     }
 
     fn print_op_and_eval_outputs(self, cli_args: &Args) {
-        fn if_terminal<T: Default>(x: T) -> T {
-            use std::io::IsTerminal;
-            thread_local! {
-                static STDOUT_IS_TERMINAL: bool = std::io::stdout().is_terminal();
-            }
-            if STDOUT_IS_TERMINAL.with(|&t| t) {
-                x
-            } else {
-                T::default()
-            }
-        }
-
-        struct FloatPrintHelper<F: FloatRepr>(F);
-        impl<F: FloatRepr> fmt::Debug for FloatPrintHelper<F> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "{c_yellow}0x{:0hex_width$x}{c_normal} {c_grey}/* {} */{c_normal}",
-                    self.0.to_bits_u128(),
-                    self.0,
-                    hex_width = F::BYTE_LEN * 2,
-                    c_normal = if_terminal("\x1b[m"),
-                    c_yellow = if_terminal("\x1b[93m"),
-                    c_grey = if_terminal("\x1b[90m"),
-                )
-            }
-        }
-
         println!(
             "  {}.{:?}",
             F::short_lowercase_name(),
@@ -497,11 +528,7 @@ where
         let print = |x, label| {
             print!("   => {:?} ({label})", FloatPrintHelper(x));
             if x != rs_apf {
-                print!(
-                    " <- {c_bold_red}!!! MISMATCH !!!{c_normal}",
-                    c_normal = if_terminal("\x1b[m"),
-                    c_bold_red = if_terminal("\x1b[1m\x1b[91m"),
-                )
+                print!(" <- {}!!! MISMATCH !!!{}", term().red_b, term().rst)
             }
             println!();
         };
@@ -528,27 +555,20 @@ fn main() {
 
     if let Some(cmd) = &cli_args.command {
         match cmd {
-            Commands::Decode { files } => {
-                for file in files {
-                    println!("{}:", file.display());
-                    let data = std::fs::read(file).unwrap();
-
-                    data.split_first()
-                        .ok_or("empty file")
-                        .and_then(|(&repr_tag, data)| {
-                            dispatch_any_float_repr_by_repr_tag!(match repr_tag {
-                                for<F: FloatRepr> => return Ok(
-                                    FuzzOp::<F>::try_decode(data)
-                                        .ok()
-                                        .ok_or(std::any::type_name::<FuzzOp<F>>())?
-                                        .print_op_and_eval_outputs(&cli_args)
-                                )
-                            });
-                            Err("first byte not valid `FloatRepr::REPR_TAG`")
-                        })
-                        .unwrap_or_else(|e| println!("  invalid data ({e})"));
+            Commands::Check { file } => {
+                let mut buf = Vec::new();
+                let reader: &mut dyn Read = match file {
+                    Some(fname) if fname == "-" => &mut io::stdin(),
+                    Some(fname) => &mut fs::File::open(fname).unwrap(),
+                    None => &mut io::stdin(),
+                };
+                reader.read_to_end(&mut buf).unwrap();
+                match decode_eval_check(&buf, &cli_args, Mode::Assert) {
+                    Ok(()) => (),
+                    Err(e) => println!("error: {e} (no panic raised)"),
                 }
             }
+            Commands::Decode { files } => run_decode_subcmd(files, &cli_args),
             Commands::Bruteforce { .. } => {
                 let mut any_mismatches = false;
                 for repr_tag in 0..=u8::MAX {
@@ -567,41 +587,984 @@ fn main() {
         return;
     }
 
-    #[cfg_attr(not(fuzzing), allow(unused))]
-    let fuzz_one_op = |data: &[u8]| {
-        data.split_first().and_then(|(&repr_tag, data)| {
-            dispatch_any_float_repr_by_repr_tag!(match repr_tag {
-                for<F: FloatRepr> => return Some(
-                    assert!(FuzzOp::<F>::try_decode(data).ok()?.eval(&cli_args).all_match())
-                )
-            });
-            None
-        });
-    };
-
     // HACK(eddyb) `#[cfg(fuzzing)] {...}` used instead of `if cfg!(fuzzing) {...}`
     // because the latter can still cause the `afl` crate to be linked, and it
     // depends on native libraries that are only available under `cargo afl ...`.
     #[cfg(fuzzing)]
     if true {
         // FIXME(eddyb) make the first argument (panic hook choice) a CLI toggle.
-        afl::fuzz(true, fuzz_one_op);
+        afl::fuzz(true, |buf| {
+            // Discard decoding errors
+            let _ = decode_eval_check(&buf, &cli_args, Mode::Assert);
+        });
 
         return;
     }
 
     // FIXME(eddyb) add better docs for all of this.
-    Args::command().print_long_help().unwrap();
-    eprintln!();
-    eprintln!("To fuzz `rustc_apfloat`, you must use `cargo afl`:");
-    eprintln!(" - `cargo install afl`");
-    eprintln!(" - build with `cargo afl build -p rustc_apfloat-fuzz --release`");
     // FIXME(eddyb) add `seed` subcommand using `FuzzOp::encode_into`, and a set
     // of basic examples, e.g. every `FuzzOp` variant with `0.0` for all inputs
     // (and/or maybe testcases from known and/or fixed bugs, too).
-    eprintln!(" - seed with `mkdir fuzz/in-foo && echo > fuzz/in-foo/empty`");
+    Args::command().print_long_help().unwrap();
     eprintln!(
-        " - run with `cargo afl fuzz -i fuzz/in-foo -o fuzz/out-foo target/release/rustc_apfloat-fuzz`"
+        "\n\
+        To fuzz `rustc_apfloat`, you must use `cargo afl`:\n\
+        - `cargo install afl`\n\
+        - build with `cargo afl build -p rustc_apfloat-fuzz --release`\n\
+        - seed with `mkdir fuzz/in-foo && echo > fuzz/in-foo/empty`\n\
+        - run with `cargo afl fuzz -i fuzz/in-foo -o fuzz/out-foo target/release/rustc_apfloat-fuzz`\n\
+        "
     );
     std::process::exit(1);
+}
+
+/// Errors from improperly formed inputs that cause an exit from the fuzzer but do not raise
+/// a test failing error.
+#[derive(Clone, Copy, Debug)]
+enum DecodeError {
+    LenShorterThan(u8, Option<u16>),
+    LenNotExactly(u8, Option<u16>),
+    InvalidOpcode(u8),
+    InvalidKind(u8),
+    InvalidRound(u8),
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecodeError::LenShorterThan(exp, act) => write!(
+                f,
+                "invalid length; expected at least {exp} bytes, got {act:?}"
+            ),
+            DecodeError::LenNotExactly(exp, act) => {
+                write!(f, "invalid length; expected {exp} bytes, got {act:?}")
+            }
+            DecodeError::InvalidOpcode(v) => write!(f, "invalid opcode {v:#04x}"),
+            DecodeError::InvalidKind(v) => write!(f, "invalid opcode {v:#04x}"),
+            DecodeError::InvalidRound(v) => write!(f, "invalid opcode {v:#04x}"),
+        }
+    }
+}
+
+/// Configuration for the current operation.
+#[derive(Debug)]
+struct EvalCfg {
+    kind: FpKind,
+    op: Op,
+    rm: Round,
+    run_cxx: bool,
+    run_host: bool,
+    ignore_cxx: Option<&'static str>,
+    ignore_cxx_status: Option<&'static str>,
+    cli_strict_host_nan_sign: bool,
+    cli_strict_host_nan_input_choice: bool,
+    cli_ignore_fma_nan_generate_vs_propagate: bool,
+}
+
+impl EvalCfg {
+    fn new(kind: FpKind, op: Op, rm: Round, cli_args: &Args) -> Self {
+        let mut ret = Self {
+            kind,
+            op,
+            rm,
+            run_cxx: !cli_args.ignore_cxx,
+            run_host: !cli_args.ignore_hard,
+            ignore_cxx: None,
+            ignore_cxx_status: None,
+            cli_strict_host_nan_sign: false,
+            cli_strict_host_nan_input_choice: false,
+            cli_ignore_fma_nan_generate_vs_propagate: false,
+        };
+
+        // FIXME: these are XFAILS / ignores and should periodically be reviewed
+        if ret.kind == FpKind::X87_F80 {
+            // LLVM never seems to set INVALID
+            ret.ignore_cxx_status = Some("LLVM does not set INVALID on X87_F80")
+        }
+        // FIXME(f8): We often disagree with LLVM, more research is neeed to see which
+        // implementation is correct.
+        if ret.kind == FpKind::F8E4M3FN {
+            ret.ignore_cxx = Some("f8e4m3fn may be broken");
+        }
+        if ret.kind == FpKind::F8E5M2 {
+            ret.ignore_cxx = Some("f8e5m2 may be broken");
+        }
+
+        // Apply CLI config
+        ret.cli_strict_host_nan_sign |= cli_args.strict_hard_nan_sign;
+        ret.cli_strict_host_nan_input_choice |= cli_args.strict_hard_nan_input_choice;
+        ret.cli_ignore_fma_nan_generate_vs_propagate |=
+            cli_args.ignore_fma_nan_generate_vs_propagate;
+
+        ret
+    }
+
+    /// Extract from a blob with CLI overrides. Return the decoded config and the remaining
+    /// bytestream.
+    fn decode<'a>(data: &'a [u8], cli_args: &Args) -> Result<(EvalCfg, &'a [u8]), DecodeError> {
+        let Some((&[kind_tag, op_tag, rm_tag], rest)) = data.split_first_chunk() else {
+            return Err(DecodeError::LenShorterThan(3, data.len().try_into().ok()));
+        };
+
+        let Some(kind) = FpKind::from_u8(kind_tag) else {
+            return Err(DecodeError::InvalidKind(op_tag));
+        };
+
+        let Some(op) = Op::from_u8(op_tag) else {
+            return Err(DecodeError::InvalidOpcode(op_tag));
+        };
+
+        let Some(rm) = round_from_u8(rm_tag) else {
+            return Err(DecodeError::InvalidRound(op_tag));
+        };
+
+        let ret = EvalCfg::new(kind, op, rm, cli_args);
+        Ok((ret, rest))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Mode {
+    /// Print the results of checking but don't panic. Used for decoding error results.
+    PrintOnly,
+    /// Exit on failure, used when actually running the fuzzer.
+    Assert,
+}
+
+/// Decode and evaluate all passed files without exiting on mismatches.
+fn run_decode_subcmd(files: &[PathBuf], cli_args: &Args) {
+    let mut buf = Vec::new();
+    for path in files {
+        println!("{}{}:{}", term().dim, path.display(), term().rst);
+
+        buf.clear();
+        let mut f = fs::File::open(path).unwrap();
+        f.read_to_end(&mut buf).unwrap();
+
+        match decode_eval_check(&buf, cli_args, Mode::PrintOnly) {
+            Ok(()) => (),
+            Err(e) => println!("error decoding file: {e}"),
+        }
+    }
+}
+
+/// Main runner: decode a config, inputs based on that config, and then evaluate the results
+/// for Rust, LLVM APFloat, and the host.
+fn decode_eval_check(data: &[u8], cli_args: &Args, mode: Mode) -> Result<(), DecodeError> {
+    let (cfg, data) = EvalCfg::decode(data, cli_args)?;
+    match cfg.kind {
+        FpKind::Ieee16 => {
+            let (a, b, c, r) = decode_for_ty_eval::<Ieee16>(&cfg, data)?;
+            r.check_all(&cfg, a, b, c, mode);
+        }
+        FpKind::Ieee32 => {
+            let (a, b, c, r) = decode_for_ty_eval::<Ieee32>(&cfg, data)?;
+            r.check_all(&cfg, a, b, c, mode);
+        }
+        FpKind::Ieee64 => {
+            let (a, b, c, r) = decode_for_ty_eval::<Ieee64>(&cfg, data)?;
+            r.check_all(&cfg, a, b, c, mode);
+        }
+        FpKind::Ieee128 => {
+            let (a, b, c, r) = decode_for_ty_eval::<Ieee128>(&cfg, data)?;
+            r.check_all(&cfg, a, b, c, mode);
+        }
+        FpKind::F8E5M2 => {
+            let (a, b, c, r) = decode_for_ty_eval::<F8E5M2>(&cfg, data)?;
+            r.check_all(&cfg, a, b, c, mode);
+        }
+        FpKind::F8E4M3FN => {
+            let (a, b, c, r) = decode_for_ty_eval::<F8E4M3FN>(&cfg, data)?;
+            r.check_all(&cfg, a, b, c, mode);
+        }
+        FpKind::BrainF16 => {
+            let (a, b, c, r) = decode_for_ty_eval::<BrainF16>(&cfg, data)?;
+            r.check_all(&cfg, a, b, c, mode);
+        }
+        FpKind::X87_F80 => {
+            let (a, b, c, r) = decode_for_ty_eval::<X87_F80>(&cfg, data)?;
+            r.check_all(&cfg, a, b, c, mode);
+        }
+    }
+
+    Ok(())
+}
+
+/// Decode operands for a given type and operation, then evaluate.
+fn decode_for_ty_eval<F: FloatRepr>(
+    cfg: &EvalCfg,
+    data: &[u8],
+) -> Result<(F, F, F, FuzzOpEvalOutputs2<F>), DecodeError>
+where
+    Single: FloatConvert<<F as FloatRepr>::RustcApFloat>,
+    Double: FloatConvert<<F as FloatRepr>::RustcApFloat>,
+{
+    let (a, b, c) = decode_operands::<F>(cfg.op, data)?;
+
+    // Evaluate the APFloat version as well as all possible references.
+    let r = FuzzOpEvalOutputs2 {
+        rs_apf: eval_rust_ap(cfg.op, cfg.rm, a, b, c),
+        cxx_apf: cfg
+            .run_cxx
+            .then(|| F::cxx_apf_eval_fuzz_op2(cfg.op, cfg.rm, a, b, c)),
+        host: cfg
+            .run_host
+            .then(|| F::host_eval_fuzz_op_if_supported2(cfg.op, cfg.rm, a, b, c))
+            .flatten(),
+    };
+
+    Ok((a, b, c, r))
+}
+
+/// Given a N-arity opcode, decode N `F`s from `data` and return zero in any remaining
+/// positions.
+fn decode_operands<F: FloatRepr>(op: Op, data: &[u8]) -> Result<(F, F, F), DecodeError> {
+    let arity = op.airity() as usize;
+    let req_len = arity * F::BYTE_LEN;
+    if data.len() != req_len {
+        return Err(DecodeError::LenNotExactly(
+            req_len.try_into().unwrap(),
+            data.len().try_into().ok(),
+        ));
+    }
+
+    let mut ret: (F, F, F) = Default::default();
+    ret.0 = F::from_le_bytes(&data[..F::BYTE_LEN]);
+    if arity > 1 {
+        ret.1 = F::from_le_bytes(&data[F::BYTE_LEN..(F::BYTE_LEN * 2)]);
+    }
+    if arity > 2 {
+        ret.2 = F::from_le_bytes(&data[(F::BYTE_LEN * 2)..(F::BYTE_LEN * 3)]);
+    }
+
+    Ok(ret)
+}
+
+/// Collected outputs from all input sources.
+struct FuzzOpEvalOutputs2<F> {
+    rs_apf: StatusAnd<F>,
+    cxx_apf: Option<StatusAnd<F>>,
+    host: Option<StatusAnd<F>>,
+}
+
+impl<F: FloatRepr> FuzzOpEvalOutputs2<F> {
+    /// Validate that outputs are correct. May unconitionally print all values or exit on error
+    /// base on the mode (mismatches always print).
+    fn check_all(&self, cfg: &EvalCfg, a: F, b: F, c: F, mode: Mode) {
+        let (always_print, always_assert) = match mode {
+            Mode::PrintOnly => (true, false),
+            Mode::Assert => (false, true),
+        };
+
+        let print_float = |x: StatusAnd<F>,
+                           label,
+                           error,
+                           stat_error,
+                           ignore: Option<&str>,
+                           ignore_stat: Option<&str>| {
+            print!(
+                "   => {:?} {:?} ({label})",
+                FloatPrintHelper(x.value),
+                x.status
+            );
+            if error {
+                let c = if ignore.is_some() {
+                    term().yel_b
+                } else {
+                    term().red_b
+                };
+                print!(" <- {c}!!! MISMATCH ");
+                if let Some(reason) = ignore {
+                    print!("(ignored, {reason}) ");
+                }
+                print!("!!!{}", term().rst);
+            } else if stat_error {
+                let c = if ignore.is_some() {
+                    term().yel_b
+                } else {
+                    term().red_b
+                };
+                print!(" <- {c}!!! STATUS MISMATCH ");
+                if let Some(reason) = ignore_stat {
+                    print!("(ignored, {reason}) ");
+                }
+                print!("!!!{}", term().rst);
+            }
+
+            println!();
+        };
+
+        #[derive(Debug)]
+        struct Results {
+            cxx_error: bool,
+            cxx_ignore: Option<&'static str>,
+            cxx_stat_error: bool,
+            cxx_stat_ignore: Option<&'static str>,
+            host_error: bool,
+            host_ignore: Option<&'static str>,
+            host_stat_error: bool,
+            host_stat_ignore: Option<&'static str>,
+        }
+
+        let mut res = Results {
+            cxx_error: false,
+            cxx_ignore: cfg.ignore_cxx,
+            cxx_stat_error: false,
+            cxx_stat_ignore: cfg.ignore_cxx_status,
+            host_error: false,
+            host_ignore: None,
+            host_stat_error: false,
+            host_stat_ignore: (!F::HOST_SUPPORTS_FP_ENV).then_some("host does not support fpenv"),
+        };
+
+        if let Some(cxx_res) = self.cxx_apf {
+            res.cxx_error = self.rs_apf.value != cxx_res.value;
+            res.cxx_stat_error = self.rs_apf.status != cxx_res.status;
+            res.cxx_ignore = res
+                .cxx_ignore
+                .or_else(|| ignore_cxx(cfg, a, b, c, self.rs_apf.value, cxx_res.value));
+        }
+
+        if let Some(host_res) = self.host {
+            res.host_error = self.rs_apf.value != host_res.value;
+            res.host_stat_error = self.rs_apf.status != host_res.status;
+            res.host_ignore = res
+                .host_ignore
+                .or_else(|| ignore_host(cfg, a, b, c, self.rs_apf.value, host_res.value));
+        }
+
+        let failure = (res.cxx_error && res.cxx_ignore.is_none())
+            || (res.cxx_stat_error && res.cxx_ignore.is_none() && res.cxx_stat_ignore.is_none())
+            || (res.host_error && res.host_ignore.is_none())
+            || (res.host_stat_error && res.host_ignore.is_none() && res.host_stat_ignore.is_none());
+
+        if always_print || failure {
+            print!("  {}.{:?}(", F::short_lowercase_name(), cfg.op,);
+
+            let airity = cfg.op.airity() as u8;
+            print!("{:?}", FloatPrintHelper(a));
+            if airity > 1 {
+                print!(", {:?}", FloatPrintHelper(b));
+            }
+            if airity > 2 {
+                print!(", {:?}", FloatPrintHelper(c));
+            }
+            println!(", {:?})", cfg.rm);
+
+            print_float(
+                self.rs_apf,
+                "Rust / rustc_apfloat",
+                false,
+                false,
+                None,
+                None,
+            );
+            if let Some(cxx_res) = self.cxx_apf {
+                print_float(
+                    cxx_res,
+                    "C++ / llvm::APFloat",
+                    res.cxx_error,
+                    res.cxx_stat_error,
+                    res.cxx_ignore,
+                    res.cxx_stat_ignore,
+                );
+            }
+            if let Some(host_res) = self.host {
+                print_float(
+                    host_res,
+                    "native host floats",
+                    res.host_error,
+                    res.host_stat_error,
+                    res.host_ignore,
+                    res.host_stat_ignore,
+                );
+            }
+        }
+
+        if always_assert && failure {
+            panic!("mismatched results: {cfg:#?}\n{res:#?}");
+        }
+    }
+}
+
+/// Return `Some(reason)` if we can ignore mismatches against the host, `None` otherwise.
+fn ignore_cxx<F: FloatRepr>(
+    cfg: &EvalCfg,
+    a: F,
+    _b: F,
+    _c: F,
+    rs_apf: F,
+    cxx_res: F,
+) -> Option<&'static str> {
+    let rs_apf_bits = rs_apf.to_bits_u128();
+    let cxx_bits = cxx_res.to_bits_u128();
+    if rs_apf_bits == cxx_bits {
+        return None;
+    }
+
+    let Masks { qnan_bit_mask, .. } = Masks::for_float::<F>();
+
+    // For the F1->F2->F1 conversions where F1 and F2 are the same type, it seems like LLVM
+    // doesn't actually do a conversion which means that sNaNs do not wind up quiet.
+    if ((cfg.kind == FpKind::Ieee32 && cfg.op == Op::FToSingleToF)
+        || (cfg.kind == FpKind::Ieee64 && cfg.op == Op::FToDoubleToF))
+        && a.to_ap().is_signaling()
+        && (cxx_bits | qnan_bit_mask) == rs_apf_bits
+    {
+        return Some("unquieted sNaN for same-size float");
+    }
+
+    None
+}
+
+/// Return `Some(reason)` if we can ignore mismatches against the host, `None` otherwise.
+fn ignore_host<F: FloatRepr>(
+    cfg: &EvalCfg,
+    a: F,
+    b: F,
+    c: F,
+    rs_apf: F,
+    host_res: F,
+) -> Option<&'static str> {
+    let rs_apf_bits = rs_apf.to_bits_u128();
+    let host_bits = host_res.to_bits_u128();
+    if rs_apf_bits == host_bits {
+        return None;
+    }
+
+    let Masks {
+        sign_bit_mask,
+        exp_mask,
+        sig_mask,
+        qnan_bit_mask,
+    } = Masks::for_float::<F>();
+
+    let is_nan = |bits| {
+        let is_nan = (bits & exp_mask) == exp_mask && (bits & sig_mask) != 0;
+        assert_eq!(F::RustcApFloat::from_bits(bits).is_nan(), is_nan);
+        is_nan
+    };
+
+    // Everything else is for handling NaNs.
+    if !(is_nan(host_bits) && is_nan(rs_apf_bits)) {
+        return None;
+    }
+
+    // Allow using CLI flags to toggle whether differences vs hardware are
+    // erased (by copying e.g. signs from the `rustc_apfloat` result) or kept.
+    let zero_sign_mask = if cfg.cli_strict_host_nan_sign {
+        u128::MAX
+    } else {
+        !sign_bit_mask
+    };
+
+    let host_zero_sign = host_bits & zero_sign_mask;
+    let rs_apf_zero_sign = rs_apf_bits & zero_sign_mask;
+
+    if host_zero_sign == rs_apf_zero_sign {
+        return Some("ignoring NaN sign");
+    }
+
+    // There is still a NaN payload difference, check if they both
+    // are propagated inputs (verbatim or at most "quieted" if SNaN),
+    // because in some cases with multiple NaN inputs, something
+    // (hardware or even e.g. LLVM passes or instruction selection)
+    // along the way from Rust code to final results, can end up
+    // causing a different input NaN to get propagated to the result.
+    if !cfg.cli_strict_host_nan_input_choice {
+        let mut host_propagated_any = true;
+        let mut rs_apf_propagated_any = true;
+
+        for m in [a, b, c] {
+            let in_bits = m.to_bits_u128();
+            // NOTE(eddyb) this `is_nan` check is important, as
+            // `INFINITY.to_bits() | qnan_bit_mask == NAN.to_bits()`,
+            // i.e. seeting the QNaN is more than enough to turn
+            // a non-NaN (infinities, specifically) into a NaN.
+            if !is_nan(in_bits) {
+                continue;
+            }
+
+            // Make sure to "quiet" (i.e. turn SNaN into QNaN)
+            // the input first, as propagation does (in the
+            // default exception handling mode, at least).
+            let in_quiet = in_bits | qnan_bit_mask;
+            let in_zero_sign = in_quiet & zero_sign_mask;
+
+            if in_zero_sign == host_zero_sign {
+                host_propagated_any = true;
+            }
+
+            if in_zero_sign == rs_apf_zero_sign {
+                rs_apf_propagated_any = true;
+            }
+        }
+
+        // Note that this allows propagating any NaN, even if not the same.
+        if host_propagated_any && rs_apf_propagated_any {
+            return Some("both are propagated inputs");
+        }
+    }
+
+    // HACK(eddyb) last chance to hide a NaN payload difference,
+    // in this case for FMAs of the form `a * b + NaN`, when `a * b`
+    // generates a new NaN (which hardware can ignore in favor of the
+    // existing NaN, but APFloat returns the fresh default NaN instead).
+    if cfg.cli_ignore_fma_nan_generate_vs_propagate {
+        if cfg.op == Op::MulAdd
+            && !is_nan(a.to_bits_u128())
+            && !is_nan(b.to_bits_u128())
+            && is_nan(c.to_bits_u128())
+            && host_zero_sign == (c.to_bits_u128() | qnan_bit_mask) & zero_sign_mask
+            && rs_apf_bits == F::RustcApFloat::NAN.to_bits()
+        {
+            return Some("fresh NaN from FMA");
+        }
+    }
+
+    // None of the patterns matched, we're not going to ignore the mismatch
+    None
+}
+
+/// Execute the requested operation as an AP float with the given rounding mode.
+fn eval_rust_ap<F: FloatRepr>(op: Op, rm: Round, a: F, b: F, c: F) -> StatusAnd<F>
+where
+    Single: FloatConvert<<F as FloatRepr>::RustcApFloat>,
+    Double: FloatConvert<<F as FloatRepr>::RustcApFloat>,
+{
+    let res = match op {
+        Op::Neg => Status::OK.and(-a.to_ap()),
+        Op::Add => a.to_ap().add_r(b.to_ap(), rm),
+        Op::Sub => a.to_ap().sub_r(b.to_ap(), rm),
+        Op::Mul => a.to_ap().mul_r(b.to_ap(), rm),
+        Op::Div => a.to_ap().div_r(b.to_ap(), rm),
+        // FIXME: rem disregards rounding mode
+        Op::Rem => a.to_ap() % b.to_ap(),
+        Op::MulAdd => a.to_ap().mul_add_r(b.to_ap(), c.to_ap(), rm),
+        // FIXME: the below operations discard a status. We should turn them into
+        // unidirectional operations.
+        Op::FToI128ToF => {
+            F::RustcApFloat::from_i128_r(a.to_ap().to_i128_r(128, rm, &mut false).value, rm)
+        }
+        Op::FToU128ToF => {
+            F::RustcApFloat::from_u128_r(a.to_ap().to_u128_r(128, rm, &mut false).value, rm)
+        }
+        Op::FToSingleToF => FloatConvert::<F::RustcApFloat>::convert_r(
+            FloatConvert::<ieee::Single>::convert_r(a.to_ap(), rm, &mut false).value,
+            rm,
+            &mut false,
+        ),
+        Op::FToDoubleToF => FloatConvert::<F::RustcApFloat>::convert_r(
+            FloatConvert::<ieee::Double>::convert_r(a.to_ap(), rm, &mut false).value,
+            rm,
+            &mut false,
+        ),
+    };
+
+    res.map(F::from_ap)
+}
+
+/// Execute the requested operation on the host with the given rounding mode, if possible. If
+/// the operation is not possible for whatever reason, return `None`.
+fn eval_host<F: HostFloat>(
+    op: Op,
+    rm: Round,
+    a: F::UInt,
+    b: F::UInt,
+    c: F::UInt,
+) -> Option<StatusAnd<F::UInt>> {
+    let a = F::from_bits(a);
+    let b = F::from_bits(b);
+    let c = F::from_bits(c);
+
+    let res = match op {
+        Op::Neg => Status::OK.and(a.neg()),
+        Op::Add => a.add_r(b, rm)?,
+        Op::Sub => a.sub_r(b, rm)?,
+        Op::Mul => a.mul_r(b, rm)?,
+        Op::Div => a.div_r(b, rm)?,
+        // FIXME: rem disregards rounding mode
+        Op::Rem => Status::OK.and(a.rem(b)),
+        Op::MulAdd => a.mul_add_r(b, c, rm)?,
+        // FIXME: the below operations discard a status. We should turn them into
+        // unidirectional operations.
+        Op::FToI128ToF => F::from_i128_r(a.to_i128_r(rm)?.value, rm)?,
+        Op::FToU128ToF => F::from_u128_r(a.to_u128_r(rm)?.value, rm)?,
+        Op::FToSingleToF => F::from_single_r(a.to_single_r(rm)?.value, rm)?,
+        Op::FToDoubleToF => F::from_double_r(a.to_double_r(rm)?.value, rm)?,
+    };
+
+    Some(res.map(F::to_bits))
+}
+
+/// Abstraction over host float operations. If the requested rounding mode is not supported,
+/// return `None`.
+trait HostFloat: Copy + Sized + fmt::Debug {
+    type UInt: Copy + fmt::LowerHex;
+    fn from_bits(bits: Self::UInt) -> Self;
+    fn to_bits(self) -> Self::UInt;
+    fn neg(self) -> Self;
+    fn add_r(self, other: Self, rm: Round) -> Option<StatusAnd<Self>>;
+    fn sub_r(self, other: Self, rm: Round) -> Option<StatusAnd<Self>>;
+    fn mul_r(self, other: Self, rm: Round) -> Option<StatusAnd<Self>>;
+    fn div_r(self, other: Self, rm: Round) -> Option<StatusAnd<Self>>;
+    fn rem(self, other: Self) -> Self;
+    fn mul_add_r(self, mul: Self, add: Self, rm: Round) -> Option<StatusAnd<Self>>;
+    fn to_i128_r(self, rm: Round) -> Option<StatusAnd<i128>>;
+    fn from_i128_r(x: i128, rm: Round) -> Option<StatusAnd<Self>>;
+    fn to_u128_r(self, rm: Round) -> Option<StatusAnd<u128>>;
+    fn from_u128_r(x: u128, rm: Round) -> Option<StatusAnd<Self>>;
+    fn to_double_r(self, rm: Round) -> Option<StatusAnd<f64>>;
+    fn from_double_r(x: f64, rm: Round) -> Option<StatusAnd<Self>>;
+    fn to_single_r(self, rm: Round) -> Option<StatusAnd<f32>>;
+    fn from_single_r(x: f32, rm: Round) -> Option<StatusAnd<Self>>;
+}
+
+macro_rules! impl_host_float {
+    ($ty:ty, $ity:ty) => {
+        impl HostFloat for $ty {
+            type UInt = $ity;
+            fn from_bits(bits: Self::UInt) -> Self {
+                Self::from_bits(bits)
+            }
+            fn to_bits(self) -> Self::UInt {
+                self.to_bits()
+            }
+            fn neg(self) -> Self {
+                -self
+            }
+            fn add_r(self, other: Self, rm: Round) -> Option<StatusAnd<Self>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(self + other)),
+                    _ => None,
+                }
+            }
+            fn sub_r(self, other: Self, rm: Round) -> Option<StatusAnd<Self>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(self - other)),
+                    _ => None,
+                }
+            }
+            fn mul_r(self, other: Self, rm: Round) -> Option<StatusAnd<Self>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(self * other)),
+                    _ => None,
+                }
+            }
+            fn div_r(self, other: Self, rm: Round) -> Option<StatusAnd<Self>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(self / other)),
+                    _ => None,
+                }
+            }
+            fn rem(self, other: Self) -> Self {
+                self % other
+            }
+            fn mul_add_r(self, mul: Self, add: Self, rm: Round) -> Option<StatusAnd<Self>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(self.mul_add(mul, add))),
+                    _ => None,
+                }
+            }
+
+            /* float->int casts are toward zero */
+            fn to_i128_r(self, rm: Round) -> Option<StatusAnd<i128>> {
+                match rm {
+                    Round::TowardZero => Some(Status::OK.and(self as i128)),
+                    _ => None,
+                }
+            }
+            fn to_u128_r(self, rm: Round) -> Option<StatusAnd<u128>> {
+                match rm {
+                    Round::TowardZero => Some(Status::OK.and(self as u128)),
+                    _ => None,
+                }
+            }
+
+            fn from_i128_r(x: i128, rm: Round) -> Option<StatusAnd<Self>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(x as Self)),
+                    _ => None,
+                }
+            }
+            fn from_u128_r(x: u128, rm: Round) -> Option<StatusAnd<Self>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(x as Self)),
+                    _ => None,
+                }
+            }
+            fn to_double_r(self, rm: Round) -> Option<StatusAnd<f64>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(self as f64)),
+                    _ => None,
+                }
+            }
+            fn from_double_r(x: f64, rm: Round) -> Option<StatusAnd<Self>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(x as Self)),
+                    _ => None,
+                }
+            }
+            fn to_single_r(self, rm: Round) -> Option<StatusAnd<f32>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(self as f32)),
+                    _ => None,
+                }
+            }
+            fn from_single_r(x: f32, rm: Round) -> Option<StatusAnd<Self>> {
+                match rm {
+                    Round::NearestTiesToEven => Some(Status::OK.and(x as Self)),
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+#[cfg(target_has_reliable_f16)]
+impl_host_float!(f16, u16);
+impl_host_float!(f32, u32);
+impl_host_float!(f64, u64);
+#[cfg(target_has_reliable_f128)]
+impl_host_float!(f128, u128);
+
+struct FloatPrintHelper<F: FloatRepr>(F);
+impl<F: FloatRepr> fmt::Debug for FloatPrintHelper<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{cy}0x{hex:0hex_width$x}{rst} {gry}/* {repr} */{rst}",
+            hex = self.0.to_bits_u128(),
+            repr = self.0,
+            hex_width = F::BYTE_LEN * 2,
+            rst = term().rst,
+            cy = term().cy,
+            gry = term().gry
+        )
+    }
+}
+
+/// Decode a rounding mode.
+fn round_from_u8(tag: u8) -> Option<Round> {
+    let v = match tag {
+        x if x == round_to_u8(Round::NearestTiesToEven) => Round::NearestTiesToEven,
+        x if x == round_to_u8(Round::TowardZero) => Round::TowardZero,
+        x if x == round_to_u8(Round::TowardPositive) => Round::TowardPositive,
+        x if x == round_to_u8(Round::TowardNegative) => Round::TowardNegative,
+        x if x == round_to_u8(Round::NearestTiesToAway) => Round::NearestTiesToAway,
+        _ => return None,
+    };
+    Some(v)
+}
+
+/// Encode a rounding mode.
+fn round_to_u8(rm: Round) -> u8 {
+    match rm {
+        Round::NearestTiesToEven => 0,
+        Round::TowardZero => 1,
+        Round::TowardPositive => 2,
+        Round::TowardNegative => 3,
+        Round::NearestTiesToAway => 4,
+    }
+}
+
+/// Masks for bitwise operations.
+#[derive(Clone, Copy, Debug)]
+struct Masks {
+    sign_bit_mask: u128,
+    exp_mask: u128,
+    sig_mask: u128,
+    qnan_bit_mask: u128,
+}
+
+impl Masks {
+    fn for_float<F: FloatRepr>() -> Self {
+        // HACK(eddyb) to avoid putting this behind a `HasHardFloat` bound,
+        // we hardcode some aspects of the IEEE binary float representation,
+        // relying on `rustc_apfloat`-provided constants as a source of truth.
+        let sign_bit_mask = 1 << (F::BIT_WIDTH - 1);
+        let exp_mask = F::RustcApFloat::INFINITY.to_bits();
+        let sig_mask = (1 << exp_mask.trailing_zeros()) - 1;
+        let qnan_bit_mask = (sig_mask + 1) >> 1;
+
+        Self {
+            sign_bit_mask,
+            exp_mask,
+            sig_mask,
+            qnan_bit_mask,
+        }
+    }
+}
+
+/// Helper for printing with color.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Default)]
+struct Colors {
+    bold: &'static str,
+    dim: &'static str,
+    gry: &'static str,
+    red_b: &'static str,
+    grn: &'static str,
+    yel: &'static str,
+    yel_b: &'static str,
+    cy: &'static str,
+    rst: &'static str,
+}
+
+thread_local! {
+    static COLORS: Colors = {
+        if io::stdout().is_terminal() {
+            Colors {
+                bold: "\x1b[1m",
+                dim: "\x1b[2m",
+                gry: "\x1b[90m",
+                red_b: "\x1b[1m\x1b[91m",
+                grn: "\x1b[92m",
+                yel: "\x1b[93m",
+                yel_b: "\x1b[1m\x1b[93m",
+                cy: "\x1b[96m",
+                rst: "\x1b[m",
+            }
+        } else {
+            Colors::default()
+        }
+    }
+}
+
+fn term() -> Colors {
+    COLORS.with(|x| *x)
+}
+
+/// Interop for items that cross the FFI bounary.
+mod cxx {
+    use super::*;
+    use std::ffi::{CStr, c_char};
+
+    macro_rules! make_extern {
+        ($F:ty, $name:ident) => {
+            pub safe fn $name(
+                opcode: u8,
+                round: u8,
+                ai: <$F as FloatRepr>::Repr,
+                bi: <$F as FloatRepr>::Repr,
+                ci: <$F as FloatRepr>::Repr,
+                out: &mut <$F as FloatRepr>::Repr,
+            ) -> i32;
+        };
+    }
+
+    // SAFETY: matches definition in `ap_fuzz.cpp`
+    unsafe extern "C" {
+        fn check_error() -> *const c_char;
+
+        make_extern!(BrainF16, cxx_apf_eval_op_brainf16);
+        make_extern!(Ieee16, cxx_apf_eval_op_ieee16);
+        make_extern!(Ieee32, cxx_apf_eval_op_ieee32);
+        make_extern!(Ieee64, cxx_apf_eval_op_ieee64);
+        make_extern!(Ieee128, cxx_apf_eval_op_ieee128);
+        // Not defined here
+        // make_extern!(PPCDoubleDouble, cxx_apf_eval_op_ppcdoubledouble);
+        make_extern!(F8E5M2, cxx_apf_eval_op_f8e5m2);
+        make_extern!(F8E4M3FN, cxx_apf_eval_op_f8e4m3fn);
+        make_extern!(X87_F80, cxx_apf_eval_op_x87_f80);
+    }
+
+    /// Return the caught exception's error if present.
+    fn error() -> Option<String> {
+        unsafe {
+            let p = check_error();
+            if p.is_null() {
+                return None;
+            }
+
+            let s = CStr::from_ptr(p);
+            Some(s.to_string_lossy().into_owned())
+        }
+    }
+
+    /// Turn a status integer into our `Status`.
+    pub fn decode_status(mut status: i32) -> Status {
+        if status < 0 {
+            panic!("error from c++: {}", error().unwrap())
+        }
+
+        let mut res = Status::OK;
+
+        let invalid = 0x01;
+        let divby0 = 0x02;
+        let oflow = 0x04;
+        let uflow = 0x08;
+        let inexact = 0x10;
+
+        if status & invalid != 0 {
+            res |= Status::INVALID_OP;
+            status &= !invalid;
+        }
+        if status & divby0 != 0 {
+            res |= Status::DIV_BY_ZERO;
+            status &= !divby0;
+        }
+        if status & oflow != 0 {
+            res |= Status::OVERFLOW;
+            status &= !oflow;
+        }
+        if status & uflow != 0 {
+            res |= Status::UNDERFLOW;
+            status &= !uflow;
+        }
+        if status & inexact != 0 {
+            res |= Status::INEXACT;
+            status &= !inexact;
+        }
+        assert_eq!(status, 0, "uncleared status flags: {status:#010x}");
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_masks() {
+        // Ensure our masks are correct
+        mask_assertions::<Ieee16>();
+        mask_assertions::<Ieee32>();
+        mask_assertions::<Ieee64>();
+        mask_assertions::<Ieee128>();
+        mask_assertions::<F8E5M2>();
+        mask_assertions::<F8E4M3FN>();
+        mask_assertions::<BrainF16>();
+        mask_assertions::<X87_F80>();
+    }
+
+    fn mask_assertions<F: FloatRepr>() {
+        let masks = Masks::for_float::<F>();
+        println!("{} masks: {masks:#?}", F::NAME);
+        let Masks {
+            sign_bit_mask,
+            exp_mask,
+            sig_mask,
+            qnan_bit_mask,
+        } = masks;
+
+        // Sanity Checks
+        assert_eq!(
+            sign_bit_mask | exp_mask | sig_mask,
+            !0 >> (128 - F::BIT_WIDTH)
+        );
+        assert!((sig_mask + 1).is_power_of_two());
+        assert!(((exp_mask | sig_mask) + 1).is_power_of_two());
+        assert_eq!(
+            sign_bit_mask.count_ones() + exp_mask.count_ones() + sig_mask.count_ones(),
+            F::BIT_WIDTH as u32
+        );
+        if F::KIND == FpKind::F8E4M3FN {
+            // No infinity or NaN for this version
+            assert_eq!(qnan_bit_mask, 0);
+        } else {
+            assert!(qnan_bit_mask.is_power_of_two());
+        }
+        assert_eq!(exp_mask | qnan_bit_mask, F::RustcApFloat::NAN.to_bits());
+    }
 }


### PR DESCRIPTION
There are a number of chnages here that aren't easy to split up:

* Accept rounding mode as an input, and check status flags as an output.
* Catch C++ exceptions (if enabled) in C++ rather than relying on `catch_unwind` in Rust.
* A `DecodeError` type is introduced for propagating parse failures, i.e.  when the fuzzer gives us an invalid binary. This means `catch_unwind` can be eliminated and panics can be reserved for failures we want the fuzzer to detect.
* Rename "hard" to "host" since host floats can be softfloat.
* Ignore NaN mismatches with reasons, rather than fixing up the outputs.
* Similarly ignore NaN mismatches when the input is signaling and there is a F1->F2->F1 roundtrip with F1 and F2 as the same float, since LLVM may do nothing here.
* Add a CLI option to check a single file like the fuzzer does.

This introduces some code duplication since the brute force tests are mostly untouched, and those use some of the same logic. A future commit will clean this up.

There are some failures here that may be resolved in future LLVM commits. Examples:

    fuzz/out-foo5/default/crashes/id:000027,sig:06,src:000855,time:629681,execs:17464051,op:havoc,rep:1:
      f16.MulAdd(0x23ff /* 0.015617 */, 0x17ff /* 0.0019522 */, 0x80ff /* -1.5199E-5 */, NearestTiesToEven)
       => 0x0101 /* 1.5318E-5 */ Status(UNDERFLOW | INEXACT) (Rust / rustc_apfloat)
       => 0x0100 /* 1.5259E-5 */ Status(UNDERFLOW | INEXACT) (C++ / llvm::APFloat) <- !!! MISMATCH !!!

LLVM has the incorrect result here.

    fuzz/sync/fuzzer02/crashes/id:000021,sig:06,src:001760,time:533420,execs:9318705,op:havoc,rep:1:
      brainf16.MulAdd(0xbe01 /* -0.126 */, 0x007f /* 1.166E-38 */, 0x0010 /* 1.469E-39 */, NearestTiesToAway)
       => 0x0000 /* 0 */ Status(UNDERFLOW | INEXACT) (Rust / rustc_apfloat)
       => 0x0001 /* 9.184E-41 */ Status(UNDERFLOW | INEXACT) (C++ / llvm::APFloat) <- !!! MISMATCH !!!

Similarly, LLVM is not correct.

    fuzz/out-06/default/crashes/id:000000,sig:06,src:000060,time:1970,execs:39760,op:havoc,rep:2:
      f32.FToSingleToF(0xff800080 /* NaN */, NearestTiesToEven)
       => 0xffc00080 /* NaN */ Status(0x0) (Rust / rustc_apfloat)
       => 0xff800080 /* NaN */ Status(0x0) (C++ / llvm::APFloat) <- !!! MISMATCH !!!
       => 0xff800080 /* NaN */ Status(0x0) (native host floats) <- !!! MISMATCH (ignored, both are propagated inputs) !!!

Here Rust quiets the input sNaN. This seems like correct behavior since usually conversions on NaN do make it quiet, but it seems like for LLVM and the host floats it turns into a no-op since the size is the same.

    fuzz/sync/fuzzer02/crashes/id:000016,sig:06,src:000190,time:255651,execs:2135435,op:havoc,rep:2:
      f8e4m3fn.Add(0xfd /* -416 */, 0xe8 /* -64 */, TowardNegative)
       => 0xfe /* -448 */ Status(INEXACT) (Rust / rustc_apfloat)
       => 0xff /* NaN */ Status(OVERFLOW | INEXACT) (C++ / llvm::APFloat) <- !!! MISMATCH (ignored, f8e4m3fn may be broken) !!!

Various cases for f8e4m3fn fail, including the below that crashes in LLVM APFloat:

    target/fuzz-out/fuzzer07/crashes/id:000000,sig:06,src:000629,time:584123,execs:2204007,op:havoc,rep:1:
      f8e4m3fn.MulAdd(0x9d /* -0.102 */, 0x0a /* 0.0195 */, 0x01 /* 0.00195 */, NearestTiesToEven)
       => 0x80 /* -0 */ Status(UNDERFLOW | INEXACT) (Rust / rustc_apfloat)

In a future commit, these can all be added to the corpus.